### PR TITLE
#135: further code migration support

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -9,7 +9,7 @@ toc::[]
 :source-highlighter: rouge
 :listing-caption: Listing
 
-IMPORTANT: This document is the *Official Covenant Code of Conduct* that must be present in every DEVON or Devonfw project at the root folder as `CODE_OF_CONDUCT.asciidoc` or `CODE_OF_CONDUCT.md`. Please, include this contents in your repository and  the *Product Owner email address* in the right place below. 
+IMPORTANT: This document is the *Official Covenant Code of Conduct* that must be present in every OASP or Devonfw project at the root folder as `CODE_OF_CONDUCT.asciidoc` or `CODE_OF_CONDUCT.md`. Please, include this contents in your repository and  the *Product Owner email address* in the right place below. 
 
 == Contributor Covenant Code of Conduct
 

--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -9,7 +9,7 @@ toc::[]
 :source-highlighter: rouge
 :listing-caption: Listing
 
-IMPORTANT: This document is the *Official Covenant Code of Conduct* that must be present in every OASP or Devonfw project at the root folder as `CODE_OF_CONDUCT.asciidoc` or `CODE_OF_CONDUCT.md`. Please, include this contents in your repository and  the *Product Owner email address* in the right place below. 
+IMPORTANT: This document is the *Official Covenant Code of Conduct* that must be present in every DEVON or Devonfw project at the root folder as `CODE_OF_CONDUCT.asciidoc` or `CODE_OF_CONDUCT.md`. Please, include this contents in your repository and  the *Product Owner email address* in the right place below. 
 
 == Contributor Covenant Code of Conduct
 

--- a/CONTRIBUTING_GUIDE.adoc
+++ b/CONTRIBUTING_GUIDE.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 === Notes on Code Contributions
 
-Both projects, devon and DEVON, are intended to be easy to contribute to. One service allowing such simplicity is GitHub was therefore selected as preferred collaboration platform.
+Both projects, devon and OASP, are intended to be easy to contribute to. One service allowing such simplicity is GitHub was therefore selected as preferred collaboration platform.
 
 In order to contribute code, git and GitHub specific pull-requests are being used.
 
@@ -23,11 +23,11 @@ It is mandatory to follow the <<Contributor Covenant Code of Conduct,code of con
 
 Git is a version control system used for a coordinated and versioned collaboration of computer files. It enables a project to be easily worked on by multiple developers and contributors.
 
-GitHub is an online repository used by deonvfw and DEVON in order to host the corresponding files. Using the command line tool or the GUI Tool "GitHub Desktop" a user can easily manage project files. There are private and public repositories. Public ones (like DEVON) can be accessed by everyone, private repositories (like devon) require access permissions.
+GitHub is an online repository used by deonvfw and OASP in order to host the corresponding files. Using the command line tool or the GUI Tool "GitHub Desktop" a user can easily manage project files. There are private and public repositories. Public ones (like OASP) can be accessed by everyone, private repositories (like devon) require access permissions.
 
 ==== Creating a new user account
 
-The devon and DEVON projects use GitHub as hosting service. Therefore you'll need an account to allow collaboration. Visit https://github.com/join?source=header-home[this page] to create a new account. If available, use *your CORP username* as GitHub username and *your CORP email address*.
+The devon and OASP projects use GitHub as hosting service. Therefore you'll need an account to allow collaboration. Visit https://github.com/join?source=header-home[this page] to create a new account. If available, use *your CORP username* as GitHub username and *your CORP email address*.
 
 A GitHub account is essential for contributing code and gaining permissions to access private repositories.
 
@@ -37,12 +37,12 @@ An in-depth documentation on basic Git syntax and usage can be found on the http
 
 === Structure of our projects
 
-In total, there are three GitHub projects regarding DEVON and devon:
+In total, there are three GitHub projects regarding OASP and devon:
 
-* link:https://github.com/devon-forge[*devon-forge*]
+* link:https://github.com/oasp-forge[*oasp-forge*]
 +
 Repository used for work on the guide - Similar to the according devon repository link:https://github.com/devonfw/devon-guide/wiki[*devon-guide*]
-* link:https://github.com/devon/[*devon*]
+* link:https://github.com/oasp/[*oasp*]
 +
 The official _Open Application Standard Platform_ project repository. Usually, two main branches exist:
 
@@ -55,17 +55,17 @@ This branch contains software in release state.
 
 * link:https://github.com/devonfw/[*devonfw*]
 +
-This is a private repository. You have to be logged in and have permissions to access the project and its repositories. Similar to DEVON, there are usually two branches:
+This is a private repository. You have to be logged in and have permissions to access the project and its repositories. Similar to OASP, there are usually two branches:
 
 ** *develop*
 ** *master*
 
 === Contributing to our projects
 
-In order to contribute to our projects, developers must follow the following <<Development Guidelines,development guidelines>>. Other sources about contributing to devon/DEVON:
+In order to contribute to our projects, developers must follow the following <<Development Guidelines,development guidelines>>. Other sources about contributing to devon/OASP:
 
-* https://github.com/devon/devon4j/wiki/devon-code-contributions[DEVON code contributions]
-* https://github.com/devon/devon4j/wiki/devon-documentation[DEVON documentation]
+* https://github.com/oasp/oasp4j/wiki/oasp-code-contributions[OASP code contributions]
+* https://github.com/oasp/oasp4j/wiki/oasp-documentation[OASP documentation]
 * https://troom.capgemini.com/sites/vcc/devon/collaboration.aspx[Devon collaboration]
 
 *Every project must include the following files* in order to establish the contributing rules and facilitate the process:
@@ -77,7 +77,7 @@ In order to contribute to our projects, developers must follow the following <<D
 
 This files should be included at the root folder or in a `docs` folder. https://github.com/stevemao/github-issue-templates[This repository] is a good resource to find the perfect templates for issues and pull requests that fit in your repository. 
 
-==== Process of contributing code to the devon/DEVON projects
+==== Process of contributing code to the devon/OASP projects
 
 * Use the issue tracker to check whether the issue you would like to be working on exists. Otherwise create a new issue.
 +
@@ -101,7 +101,7 @@ git checkout develop-x.y.z
 ----
 git checkout -b myBranchName
 ----
-* Apply your modifications according to the https://github.com/devon/devon4j/wiki/coding-conventions[coding conventions] to the newly created branch
+* Apply your modifications according to the https://github.com/oasp/oasp4j/wiki/coding-conventions[coding conventions] to the newly created branch
 * Verify your changes to only include relevant and required changes.
 * Commit your changes locally
 ** When commiting changes please follow this pattern for your commit message:
@@ -123,7 +123,7 @@ For example:
 +
 [source]
 ----
-devon/devon4j#1: added REST service for tablemanagement
+oasp/oasp4j#1: added REST service for tablemanagement
 ----
 +
 *Note:* Starting directly with a # symbol will comment out the line when using the editor to insert a commit message. Instead, you should use a prefix like a space or simply typing "Issue". E.g.:

--- a/CONTRIBUTING_GUIDE.adoc
+++ b/CONTRIBUTING_GUIDE.adoc
@@ -13,7 +13,7 @@ toc::[]
 
 === Notes on Code Contributions
 
-Both projects, devon and OASP, are intended to be easy to contribute to. One service allowing such simplicity is GitHub was therefore selected as preferred collaboration platform.
+Both projects, devon and DEVON, are intended to be easy to contribute to. One service allowing such simplicity is GitHub was therefore selected as preferred collaboration platform.
 
 In order to contribute code, git and GitHub specific pull-requests are being used.
 
@@ -23,11 +23,11 @@ It is mandatory to follow the <<Contributor Covenant Code of Conduct,code of con
 
 Git is a version control system used for a coordinated and versioned collaboration of computer files. It enables a project to be easily worked on by multiple developers and contributors.
 
-GitHub is an online repository used by deonvfw and OASP in order to host the corresponding files. Using the command line tool or the GUI Tool "GitHub Desktop" a user can easily manage project files. There are private and public repositories. Public ones (like OASP) can be accessed by everyone, private repositories (like devon) require access permissions.
+GitHub is an online repository used by deonvfw and DEVON in order to host the corresponding files. Using the command line tool or the GUI Tool "GitHub Desktop" a user can easily manage project files. There are private and public repositories. Public ones (like DEVON) can be accessed by everyone, private repositories (like devon) require access permissions.
 
 ==== Creating a new user account
 
-The devon and OASP projects use GitHub as hosting service. Therefore you'll need an account to allow collaboration. Visit https://github.com/join?source=header-home[this page] to create a new account. If available, use *your CORP username* as GitHub username and *your CORP email address*.
+The devon and DEVON projects use GitHub as hosting service. Therefore you'll need an account to allow collaboration. Visit https://github.com/join?source=header-home[this page] to create a new account. If available, use *your CORP username* as GitHub username and *your CORP email address*.
 
 A GitHub account is essential for contributing code and gaining permissions to access private repositories.
 
@@ -37,12 +37,12 @@ An in-depth documentation on basic Git syntax and usage can be found on the http
 
 === Structure of our projects
 
-In total, there are three GitHub projects regarding OASP and devon:
+In total, there are three GitHub projects regarding DEVON and devon:
 
-* link:https://github.com/oasp-forge[*oasp-forge*]
+* link:https://github.com/devon-forge[*devon-forge*]
 +
 Repository used for work on the guide - Similar to the according devon repository link:https://github.com/devonfw/devon-guide/wiki[*devon-guide*]
-* link:https://github.com/oasp/[*oasp*]
+* link:https://github.com/devon/[*devon*]
 +
 The official _Open Application Standard Platform_ project repository. Usually, two main branches exist:
 
@@ -55,17 +55,17 @@ This branch contains software in release state.
 
 * link:https://github.com/devonfw/[*devonfw*]
 +
-This is a private repository. You have to be logged in and have permissions to access the project and its repositories. Similar to OASP, there are usually two branches:
+This is a private repository. You have to be logged in and have permissions to access the project and its repositories. Similar to DEVON, there are usually two branches:
 
 ** *develop*
 ** *master*
 
 === Contributing to our projects
 
-In order to contribute to our projects, developers must follow the following <<Development Guidelines,development guidelines>>. Other sources about contributing to devon/OASP:
+In order to contribute to our projects, developers must follow the following <<Development Guidelines,development guidelines>>. Other sources about contributing to devon/DEVON:
 
-* https://github.com/oasp/oasp4j/wiki/oasp-code-contributions[OASP code contributions]
-* https://github.com/oasp/oasp4j/wiki/oasp-documentation[OASP documentation]
+* https://github.com/devon/devon4j/wiki/devon-code-contributions[DEVON code contributions]
+* https://github.com/devon/devon4j/wiki/devon-documentation[DEVON documentation]
 * https://troom.capgemini.com/sites/vcc/devon/collaboration.aspx[Devon collaboration]
 
 *Every project must include the following files* in order to establish the contributing rules and facilitate the process:
@@ -77,7 +77,7 @@ In order to contribute to our projects, developers must follow the following <<D
 
 This files should be included at the root folder or in a `docs` folder. https://github.com/stevemao/github-issue-templates[This repository] is a good resource to find the perfect templates for issues and pull requests that fit in your repository. 
 
-==== Process of contributing code to the devon/OASP projects
+==== Process of contributing code to the devon/DEVON projects
 
 * Use the issue tracker to check whether the issue you would like to be working on exists. Otherwise create a new issue.
 +
@@ -101,7 +101,7 @@ git checkout develop-x.y.z
 ----
 git checkout -b myBranchName
 ----
-* Apply your modifications according to the https://github.com/oasp/oasp4j/wiki/coding-conventions[coding conventions] to the newly created branch
+* Apply your modifications according to the https://github.com/devon/devon4j/wiki/coding-conventions[coding conventions] to the newly created branch
 * Verify your changes to only include relevant and required changes.
 * Commit your changes locally
 ** When commiting changes please follow this pattern for your commit message:
@@ -123,7 +123,7 @@ For example:
 +
 [source]
 ----
-oasp/oasp4j#1: added REST service for tablemanagement
+devon/devon4j#1: added REST service for tablemanagement
 ----
 +
 *Note:* Starting directly with a # symbol will comment out the line when using the editor to insert a commit message. Instead, you should use a prefix like a space or simply typing "Issue". E.g.:

--- a/devon.json
+++ b/devon.json
@@ -1,0 +1,3 @@
+{"version": "2.0.0",
+"type":"devon4j",
+"signature":"from json"}

--- a/devon.json
+++ b/devon.json
@@ -1,3 +1,0 @@
-{"version": "2.0.0",
-"type":"oasp4j",
-"signature":"from json"}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.devonfw</groupId>
   <artifactId>devcon</artifactId>
-  <version>1.5.0</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>devcon</name>
   <description>full life cycle command line tool for Devon apps</description>
   <properties>

--- a/public/version.json
+++ b/public/version.json
@@ -3,8 +3,8 @@
   "url":"http://devonfw.github.io/download/devcon/devcon.jar",
   "devondist_file_id": "frs65334",
   "devondist_file_linux_id": "frs65335",
-  "oaspide_file_id": "frs54315",
-  "oasp4js_ang1_id": "frs51721",
-  "oasp4js_ang2_id": "frs51961",
-  "oasp_template_version": "3.0.0"
+  "devonide_file_id": "frs54315",
+  "devon4ng_ang1_id": "frs51721",
+  "devon4ng_ang2_id": "frs51961",
+  "devon_template_version": "3.0.0"
 }

--- a/public/version.json
+++ b/public/version.json
@@ -6,5 +6,5 @@
   "oaspide_file_id": "frs54315",
   "oasp4js_ang1_id": "frs51721",
   "oasp4js_ang2_id": "frs51961",
-  "oasp_template_version": "2.6.0"
+  "oasp_template_version": "3.0.0"
 }

--- a/src/main/java/com/devonfw/devcon/common/api/CommandModule.java
+++ b/src/main/java/com/devonfw/devcon/common/api/CommandModule.java
@@ -97,9 +97,9 @@ public interface CommandModule {
    * This command can be use to call Devcon command from other module. Parameter module refers to modulename , command
    * refers to command name and projectInfo is passed from existing method. ProjectInfo contains all information related
    * to respective devcon project. Usecase: We can use this method from project module to get the commands of other
-   * modules such as Devon4j, oasp4js etc. This method provide correct information for respective projects such as path
+   * modules such as Devon4j, devon4ng etc. This method provide correct information for respective projects such as path
    * etc. As an example,consider we need to build combinedproject created by devcon. From project module build method,
-   * we internally call 'Devon4j build()' and 'client(oasp4js) build()' method. But as path parameter is optional we are
+   * we internally call 'Devon4j build()' and 'client(devon4ng) build()' method. But as path parameter is optional we are
    * not including it in command method signature e.g {@link Devon4j#build()}. As this method do not have any input
    * parameter we cannot pass any value directly from project method to this called method. So we will use
    * getCommand(module,command, projectinfo) method which will pass all information required to called method.

--- a/src/main/java/com/devonfw/devcon/common/api/CommandModule.java
+++ b/src/main/java/com/devonfw/devcon/common/api/CommandModule.java
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 import com.devonfw.devcon.common.api.data.ProjectInfo;
 import com.devonfw.devcon.common.utils.ContextPathInfo;
 import com.devonfw.devcon.input.Input;
-import com.devonfw.devcon.modules.oasp4j.Oasp4j;
+import com.devonfw.devcon.modules.devon4j.Devon4j;
 import com.devonfw.devcon.output.Output;
 import com.google.common.base.Optional;
 
@@ -97,10 +97,10 @@ public interface CommandModule {
    * This command can be use to call Devcon command from other module. Parameter module refers to modulename , command
    * refers to command name and projectInfo is passed from existing method. ProjectInfo contains all information related
    * to respective devcon project. Usecase: We can use this method from project module to get the commands of other
-   * modules such as oasp4j, oasp4js etc. This method provide correct information for respective projects such as path
+   * modules such as Devon4j, oasp4js etc. This method provide correct information for respective projects such as path
    * etc. As an example,consider we need to build combinedproject created by devcon. From project module build method,
-   * we internally call 'oasp4j build()' and 'client(oasp4js) build()' method. But as path parameter is optional we are
-   * not including it in command method signature e.g {@link Oasp4j#build()}. As this method do not have any input
+   * we internally call 'Devon4j build()' and 'client(oasp4js) build()' method. But as path parameter is optional we are
+   * not including it in command method signature e.g {@link Devon4j#build()}. As this method do not have any input
    * parameter we cannot pass any value directly from project method to this called method. So we will use
    * getCommand(module,command, projectinfo) method which will pass all information required to called method.
    */

--- a/src/main/java/com/devonfw/devcon/common/api/data/DistributionInfo.java
+++ b/src/main/java/com/devonfw/devcon/common/api/data/DistributionInfo.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ import java.nio.file.Path;
 import com.github.zafarkhaja.semver.Version;
 
 /**
- * Contains information about OASP-IDE or Devon Distribution
+ * Contains information about DEVON-IDE or Devon Distribution
  *
  * @author ivanderk
  */
@@ -40,7 +40,7 @@ public interface DistributionInfo {
 
   /**
    *
-   * @return whether is OASP-IDE or Devon Distribution
+   * @return whether is DEVON-IDE or Devon Distribution
    */
   DistributionType getDistributionType();
 }

--- a/src/main/java/com/devonfw/devcon/common/api/data/DistributionType.java
+++ b/src/main/java/com/devonfw/devcon/common/api/data/DistributionType.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,11 +16,11 @@
 package com.devonfw.devcon.common.api.data;
 
 /**
- * Denotes OASP-IDE or Devon Distribution
+ * Denotes DEVON-IDE or Devon Distribution
  *
  * @author ivanderk
  */
 public enum DistributionType {
 
-  DevonDist, OASPIDE
+  DevonDist, DEVONIDE
 }

--- a/src/main/java/com/devonfw/devcon/common/api/data/InputTypeNames.java
+++ b/src/main/java/com/devonfw/devcon/common/api/data/InputTypeNames.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,6 @@ package com.devonfw.devcon.common.api.data;
  * @author ivanderk
  */
 public enum InputTypeNames {
-  GENERIC, PATH, PASSWORD, LIST /* NUMBER, */
+  GENERIC, PATH, PASSWORD, LIST, BOOLEAN /* NUMBER, */
 
 }

--- a/src/main/java/com/devonfw/devcon/common/api/data/ProjectInfo.java
+++ b/src/main/java/com/devonfw/devcon/common/api/data/ProjectInfo.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,7 +50,7 @@ public interface ProjectInfo {
 
   /**
    *
-   * @return whether is Combined project, oasp4j, oasp4js or devon4secha
+   * @return whether is Combined project, devon4j, oasp4js or devon4secha
    */
   ProjectType getProjecType();
 

--- a/src/main/java/com/devonfw/devcon/common/api/data/ProjectInfo.java
+++ b/src/main/java/com/devonfw/devcon/common/api/data/ProjectInfo.java
@@ -50,7 +50,7 @@ public interface ProjectInfo {
 
   /**
    *
-   * @return whether is Combined project, devon4j, oasp4js or devon4secha
+   * @return whether is Combined project, devon4j, devon4ng or devon4secha
    */
   ProjectType getProjecType();
 

--- a/src/main/java/com/devonfw/devcon/common/api/data/ProjectType.java
+++ b/src/main/java/com/devonfw/devcon/common/api/data/ProjectType.java
@@ -21,5 +21,5 @@ package com.devonfw.devcon.common.api.data;
  * @author ivanderk
  */
 public enum ProjectType {
-  COMBINED, DEVON4J, OASP4JS
+  COMBINED, DEVON4J, DEVON4NG
 }

--- a/src/main/java/com/devonfw/devcon/common/api/data/ProjectType.java
+++ b/src/main/java/com/devonfw/devcon/common/api/data/ProjectType.java
@@ -21,5 +21,5 @@ package com.devonfw.devcon.common.api.data;
  * @author ivanderk
  */
 public enum ProjectType {
-  COMBINED, OASP4J, OASP4JS
+  COMBINED, DEVON4J, OASP4JS
 }

--- a/src/main/java/com/devonfw/devcon/common/impl/utils/DistributionFolderProcessor.java
+++ b/src/main/java/com/devonfw/devcon/common/impl/utils/DistributionFolderProcessor.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@ import com.devonfw.devcon.common.api.utils.FolderProcessor;
 
 /**
  * Implementation of {@link FolderProcessor} which determines whether a particular folder or any of its parent folders
- * contain a Devon Distribution or OASP IDE.
+ * contain a Devon Distribution or DEVON IDE.
  *
  * @author ivanderk
  */

--- a/src/main/java/com/devonfw/devcon/common/utils/Constants.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Constants.java
@@ -116,12 +116,12 @@ public final class Constants {
   /**
    * OASP TEMPLATE GROUP ID
    */
-  public final static String OASP_TEMPLATE_GROUP_ID = "io.oasp.java.templates";
+  public final static String OASP_TEMPLATE_GROUP_ID = "com.devonfw.java.templates";
 
   /**
    * OASP ARTIFACT ID
    */
-  public final static String OASP_ARTIFACT_ID = "oasp4j-template-server";
+  public final static String OASP_ARTIFACT_ID = "devon4j-template-server";
 
   /**
    *
@@ -131,7 +131,7 @@ public final class Constants {
   /**
    *
    */
-  public final static String OASP4J = "oasp4j";
+  public final static String DEVON4J = "devon4j";
 
   /**
    *

--- a/src/main/java/com/devonfw/devcon/common/utils/Constants.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Constants.java
@@ -89,9 +89,9 @@ public final class Constants {
   public static final String DEVON_REPO_URL = "github.com/devonfw/devon.git";
 
   /**
-   * OASP4J Repo Url
+   * DEVON4J Repo Url
    */
-  public static final String OASP4J_REPO_URL = "https://github.com/oasp/oasp4j.git";
+  public static final String OASP4J_REPO_URL = "https://github.com/oasp/devon4j.git";
 
   /**
    * BAT FILE TO UPDATE ALL WORKSPACES

--- a/src/main/java/com/devonfw/devcon/common/utils/Constants.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Constants.java
@@ -91,7 +91,7 @@ public final class Constants {
   /**
    * DEVON4J Repo Url
    */
-  public static final String OASP4J_REPO_URL = "https://github.com/oasp/devon4j.git";
+  public static final String DEVON4J_REPO_URL = "https://github.com/devonfw/devon4j.git";
 
   /**
    * BAT FILE TO UPDATE ALL WORKSPACES
@@ -104,29 +104,29 @@ public final class Constants {
   public static final String WORKSPACES = "workspaces";
 
   /**
-   * OASP TEMPLATE VERSION
+   * DEVON TEMPLATE VERSION
    */
-  public final static String OASP_TEMPLATE_VERSION = "oasp_template_version";
+  public final static String DEVON_TEMPLATE_VERSION = "devon_template_version";
 
   /**
-   * OASP TEMPLATE LAST STABLE VERSION
+   * DEVON TEMPLATE LAST STABLE VERSION
    */
-  public final static String OASP_TEMPLATE_LAST_STABLE_VERSION = "2.5.0";
+  public final static String DEVON_TEMPLATE_LAST_STABLE_VERSION = "2.5.0";
 
   /**
-   * OASP TEMPLATE GROUP ID
+   * DEVON TEMPLATE GROUP ID
    */
-  public final static String OASP_TEMPLATE_GROUP_ID = "com.devonfw.java.templates";
+  public final static String DEVON_TEMPLATE_GROUP_ID = "com.devonfw.java.templates";
 
   /**
-   * OASP ARTIFACT ID
+   * DEVON ARTIFACT ID
    */
-  public final static String OASP_ARTIFACT_ID = "devon4j-template-server";
+  public final static String DEVON_ARTIFACT_ID = "devon4j-template-server";
 
   /**
    *
    */
-  public final static String OASP4JS = "oasp4js";
+  public final static String DEVON4NG = "devon4ng";
 
   /**
    *

--- a/src/main/java/com/devonfw/devcon/common/utils/ContextPathInfo.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/ContextPathInfo.java
@@ -57,7 +57,7 @@ public class ContextPathInfo {
 
   public static final ContextPathInfo INSTANCE = new ContextPathInfo();
 
-  private static final String OASP_IDE = "oasp-ide";
+  private static final String DEVON_IDE = "devon-ide";
 
   private static final String DEVON_DIST = "devon-dist";
 
@@ -71,7 +71,7 @@ public class ContextPathInfo {
 
   private static final String COMBINED = "combined";
 
-  private static final String OASP4JS = "oasp4js";
+  private static final String DEVON4NG = "devon4ng";
 
   private static final String DEVON4J = "devon4j";
 
@@ -107,7 +107,7 @@ public class ContextPathInfo {
 
   /**
    *
-   * @return Distribution Info if CWD within a Devon Distrubution or OASP IDE
+   * @return Distribution Info if CWD within a Devon Distrubution or DEVON IDE
    */
   public Optional<DistributionInfo> getDistributionRoot() {
 
@@ -117,7 +117,7 @@ public class ContextPathInfo {
   /**
    *
    * @param currentDir pass directory as String
-   * @return Distribution Info if currentDir within a Devon Distrubution or OASP IDE
+   * @return Distribution Info if currentDir within a Devon Distrubution or DEVON IDE
    */
   public Optional<DistributionInfo> getDistributionRoot(String path) {
 
@@ -131,7 +131,7 @@ public class ContextPathInfo {
   /**
    *
    * @param aPath pass directory as Path instance
-   * @return Distribution Info if currentDir within a Devon Distrubution or OASP IDE
+   * @return Distribution Info if currentDir within a Devon Distrubution or DEVON IDE
    */
   public Optional<DistributionInfo> getDistributionRoot(Path aPath) {
 
@@ -172,10 +172,11 @@ public class ContextPathInfo {
     String disttype = json.get(TYPE).toString();
     if (disttype.toLowerCase().equals(DEVON_DIST)) {
       distType = DistributionType.DevonDist;
-    } else if (disttype.toLowerCase().equals(OASP_IDE)) {
-      distType = DistributionType.OASPIDE;
+    } else if (disttype.toLowerCase().equals(DEVON_IDE)) {
+      distType = DistributionType.DEVONIDE;
     } else {
-      throw new InvalidConfigurationStateException("type property does not contain either 'devon-dist' nor 'oasp-ide'");
+      throw new InvalidConfigurationStateException(
+          "type property does not contain either 'devon-dist' nor 'devon-ide'");
     }
 
     return new DistributionInfoImpl(distPath, distType, version);
@@ -239,11 +240,11 @@ public class ContextPathInfo {
 
     } else if (projtype.toLowerCase().equals(DEVON4J)) {
       projectType = ProjectType.DEVON4J;
-    } else if (projtype.toLowerCase().equals(OASP4JS)) {
-      projectType = ProjectType.OASP4JS;
+    } else if (projtype.toLowerCase().equals(DEVON4NG)) {
+      projectType = ProjectType.DEVON4NG;
     } else {
       throw new InvalidConfigurationStateException(
-          "type property does not contain valid ProjectInfoType: 'combined', 'devon4j', 'oasp4js' ");
+          "type property does not contain valid ProjectInfoType: 'combined', 'devon4j', 'devon4ng' ");
     }
 
     /**

--- a/src/main/java/com/devonfw/devcon/common/utils/ContextPathInfo.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/ContextPathInfo.java
@@ -73,7 +73,7 @@ public class ContextPathInfo {
 
   private static final String OASP4JS = "oasp4js";
 
-  private static final String OASP4J = "oasp4j";
+  private static final String DEVON4J = "devon4j";
 
   /**
    *
@@ -237,13 +237,13 @@ public class ContextPathInfo {
         projects.add(getProjectInfo(resolved));
       }
 
-    } else if (projtype.toLowerCase().equals(OASP4J)) {
-      projectType = ProjectType.OASP4J;
+    } else if (projtype.toLowerCase().equals(DEVON4J)) {
+      projectType = ProjectType.DEVON4J;
     } else if (projtype.toLowerCase().equals(OASP4JS)) {
       projectType = ProjectType.OASP4JS;
     } else {
       throw new InvalidConfigurationStateException(
-          "type property does not contain valid ProjectInfoType: 'combined', 'oasp4j', 'oasp4js' ");
+          "type property does not contain valid ProjectInfoType: 'combined', 'devon4j', 'oasp4js' ");
     }
 
     /**

--- a/src/main/java/com/devonfw/devcon/common/utils/Utils.java
+++ b/src/main/java/com/devonfw/devcon/common/utils/Utils.java
@@ -455,17 +455,17 @@ public class Utils {
    */
   public static String getTemplateVersion(String configPath) {
 
-    String oaspTemplateVersion = "";
-    Optional<String> oaspTemplateVersionOp = Utils.getJSONConfigProperty(configPath, Constants.OASP_TEMPLATE_VERSION);
-    if (oaspTemplateVersionOp.isPresent()) {
-      oaspTemplateVersion = oaspTemplateVersionOp.get();
+    String devonTemplateVersion = "";
+    Optional<String> devonTemplateVersionOp = Utils.getJSONConfigProperty(configPath, Constants.DEVON_TEMPLATE_VERSION);
+    if (devonTemplateVersionOp.isPresent()) {
+      devonTemplateVersion = devonTemplateVersionOp.get();
     } else {
-      oaspTemplateVersionOp = Downloader.getDevconConfigProperty(Constants.OASP_TEMPLATE_VERSION);
-      if (oaspTemplateVersionOp.isPresent()) {
-        oaspTemplateVersion = oaspTemplateVersionOp.get();
+      devonTemplateVersionOp = Downloader.getDevconConfigProperty(Constants.DEVON_TEMPLATE_VERSION);
+      if (devonTemplateVersionOp.isPresent()) {
+        devonTemplateVersion = devonTemplateVersionOp.get();
       }
     }
-    return oaspTemplateVersion;
+    return devonTemplateVersion;
   }
 
 }

--- a/src/main/java/com/devonfw/devcon/input/ShowCommandHandler.java
+++ b/src/main/java/com/devonfw/devcon/input/ShowCommandHandler.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,6 +40,7 @@ import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
@@ -231,124 +232,146 @@ public class ShowCommandHandler implements EventHandler<ActionEvent> {
       Text blankText = new Text();
       switch (inputType.getName()) {
 
-      case LIST:
-        Label list = new Label(param.getName());
-        Text text = new Text(Constants.ASTRIKE);
-        text.setFill(Color.RED);
-        HBox hb = new HBox();
-        hb.getChildren().add(list);
-        if (param.isOptional()) {
-          hb.getChildren().add(blankText);
-        } else {
-          this.mandatoryParamList.add(param.getName());
-          hb.getChildren().add(text);
-        }
-
-        list.setStyle("-fx-background-color: #efeeee;");
-        grid.add(hb, 0, order); // col row
-
-        ObservableList<String> options = FXCollections.observableArrayList();
-        String[] inputVals = param.getInputType().getValues();
-        options.addAll(Arrays.asList(inputVals));
-        ComboBox<String> comboBox = new ComboBox<>(options);
-        comboBox.getSelectionModel().select(0); // default selection for option in drop down list
-        comboBox.setId("combo_" + param.getName());
-        comboBox.setTooltip(toolTip);
-        comboBox.setMinHeight(Constants.HEIGHT);
-        comboBox.setPrefWidth(Constants.WIDTH);
-        grid.add(comboBox, 1, order);
-        break;
-
-      case PASSWORD:
-        final Label message = new Label("");
-        Text text1 = new Text(Constants.ASTRIKE);
-        text1.setFill(Color.RED);
-        Label pw = new Label(param.getName());
-        pw.setStyle("-fx-background-color: #efeeee;");
-        HBox hb1 = new HBox();
-        hb1.getChildren().add(pw);
-        if (param.isOptional()) {
-          hb1.getChildren().add(blankText);
-        } else {
-          this.mandatoryParamList.add(param.getName());
-          hb1.getChildren().add(text1);
-        }
-        grid.add(hb1, 0, order); // col row
-        final PasswordField pwBox = new PasswordField();
-        pwBox.setId("password_" + param.getName());
-        pwBox.setTooltip(toolTip);
-        pwBox.setMinHeight(Constants.HEIGHT);
-        pwBox.setMaxWidth(Constants.WIDTH);
-        pwBox.setPrefWidth(Constants.WIDTH);
-        grid.add(pwBox, 1, order);
-        break;
-
-      case PATH:
-        Label path = new Label(param.getName());
-        Text text2 = new Text(Constants.ASTRIKE);
-        text2.setFill(Color.RED);
-        path.setStyle("-fx-background-color: #efeeee;");
-        HBox hb2 = new HBox();
-        hb2.getChildren().add(path);
-        if (param.isOptional()) {
-          hb2.getChildren().add(blankText);
-        } else {
-          this.mandatoryParamList.add(param.getName());
-          hb2.getChildren().add(text2);
-        }
-
-        grid.add(hb2, 0, order); // col row
-
-        HBox directorySelector = new HBox();
-
-        final TextField selectedPath = new TextField();
-        selectedPath.setText(this.cmdManager.getContextPathInfo().getCurrentWorkingDirectory().toString());
-        selectedPath.setEditable(false);
-        Button pathSelector = new Button(Constants.SELECT_PATH);
-        pathSelector.setTooltip(toolTip);
-        pathSelector.setOnAction(new EventHandler<ActionEvent>() {
-          @Override
-          public void handle(ActionEvent t) {
-
-            chooseDirectory(ShowCommandHandler.this.screenController, selectedPath);
+        case LIST:
+          Label list = new Label(param.getName());
+          Text text = new Text(Constants.ASTRIKE);
+          text.setFill(Color.RED);
+          HBox hb = new HBox();
+          hb.getChildren().add(list);
+          if (param.isOptional()) {
+            hb.getChildren().add(blankText);
+          } else {
+            this.mandatoryParamList.add(param.getName());
+            hb.getChildren().add(text);
           }
-        });
 
-        ;
+          list.setStyle("-fx-background-color: #efeeee;");
+          grid.add(hb, 0, order); // col row
 
-        directorySelector.getChildren().add(selectedPath);
-        directorySelector.getChildren().add(pathSelector);
-        directorySelector.setId("path_" + param.getName());
+          ObservableList<String> options = FXCollections.observableArrayList();
+          String[] inputVals = param.getInputType().getValues();
+          options.addAll(Arrays.asList(inputVals));
+          ComboBox<String> comboBox = new ComboBox<>(options);
+          comboBox.getSelectionModel().select(0); // default selection for option in drop down list
+          comboBox.setId("combo_" + param.getName());
+          comboBox.setTooltip(toolTip);
+          comboBox.setMinHeight(Constants.HEIGHT);
+          comboBox.setPrefWidth(Constants.WIDTH);
+          grid.add(comboBox, 1, order);
+          break;
 
-        directorySelector.setSpacing(5);
-        directorySelector.setPrefHeight(Constants.HEIGHT);
-        directorySelector.setPrefWidth(Constants.WIDTH);
-        grid.add(directorySelector, 1, order);
+        case PASSWORD:
+          final Label message = new Label("");
+          Text text1 = new Text(Constants.ASTRIKE);
+          text1.setFill(Color.RED);
+          Label pw = new Label(param.getName());
+          pw.setStyle("-fx-background-color: #efeeee;");
+          HBox hb1 = new HBox();
+          hb1.getChildren().add(pw);
+          if (param.isOptional()) {
+            hb1.getChildren().add(blankText);
+          } else {
+            this.mandatoryParamList.add(param.getName());
+            hb1.getChildren().add(text1);
+          }
+          grid.add(hb1, 0, order); // col row
+          final PasswordField pwBox = new PasswordField();
+          pwBox.setId("password_" + param.getName());
+          pwBox.setTooltip(toolTip);
+          pwBox.setMinHeight(Constants.HEIGHT);
+          pwBox.setMaxWidth(Constants.WIDTH);
+          pwBox.setPrefWidth(Constants.WIDTH);
+          grid.add(pwBox, 1, order);
+          break;
 
-        break;
+        case PATH:
+          Label path = new Label(param.getName());
+          Text text2 = new Text(Constants.ASTRIKE);
+          text2.setFill(Color.RED);
+          path.setStyle("-fx-background-color: #efeeee;");
+          HBox hb2 = new HBox();
+          hb2.getChildren().add(path);
+          if (param.isOptional()) {
+            hb2.getChildren().add(blankText);
+          } else {
+            this.mandatoryParamList.add(param.getName());
+            hb2.getChildren().add(text2);
+          }
 
-      default: /* GENERIC */
-        final Label genLabel = new Label(param.getName());
-        Text text3 = new Text(Constants.ASTRIKE);
-        text3.setFill(Color.RED);
-        genLabel.setStyle("-fx-background-color: #efeeee;");
-        HBox hb3 = new HBox();
-        hb3.getChildren().add(genLabel);
-        if (param.isOptional()) {
-          hb3.getChildren().add(blankText);
-        } else {
-          this.mandatoryParamList.add(param.getName());
-          hb3.getChildren().add(text3);
-        }
-        grid.add(hb3, 0, order);
+          grid.add(hb2, 0, order); // col row
 
-        TextField userTextField = new TextField();
-        userTextField.setMinHeight(Constants.HEIGHT);
-        userTextField.setMaxWidth(Constants.WIDTH);
-        userTextField.setId("text_" + param.getName());
-        userTextField.setTooltip(toolTip);
-        userTextField.setPromptText("Enter " + param.getName());
-        grid.add(userTextField, 1, order);
+          HBox directorySelector = new HBox();
+
+          final TextField selectedPath = new TextField();
+          selectedPath.setText(this.cmdManager.getContextPathInfo().getCurrentWorkingDirectory().toString());
+          selectedPath.setEditable(false);
+          Button pathSelector = new Button(Constants.SELECT_PATH);
+          pathSelector.setTooltip(toolTip);
+          pathSelector.setOnAction(new EventHandler<ActionEvent>() {
+            @Override
+            public void handle(ActionEvent t) {
+
+              chooseDirectory(ShowCommandHandler.this.screenController, selectedPath);
+            }
+          });
+
+          ;
+
+          directorySelector.getChildren().add(selectedPath);
+          directorySelector.getChildren().add(pathSelector);
+          directorySelector.setId("path_" + param.getName());
+
+          directorySelector.setSpacing(5);
+          directorySelector.setPrefHeight(Constants.HEIGHT);
+          directorySelector.setPrefWidth(Constants.WIDTH);
+          grid.add(directorySelector, 1, order);
+
+          break;
+
+        case BOOLEAN:
+          final Label flagLabel = new Label(param.getName());
+          flagLabel.setStyle("-fx-background-color: #efeeee;");
+          HBox hbFlag = new HBox();
+          hbFlag.getChildren().add(flagLabel);
+          if (param.isOptional()) {
+            hbFlag.getChildren().add(blankText);
+          } else {
+            this.mandatoryParamList.add(param.getName());
+            Text mandatoryMarker = new Text(Constants.ASTRIKE);
+            mandatoryMarker.setFill(Color.RED);
+            hbFlag.getChildren().add(mandatoryMarker);
+          }
+          grid.add(hbFlag, 0, order);
+
+          CheckBox checkbox = new CheckBox();
+          checkbox.setMinHeight(Constants.HEIGHT);
+          checkbox.setMaxWidth(Constants.WIDTH);
+          checkbox.setId("checkbox_" + param.getName());
+          checkbox.setTooltip(toolTip);
+          grid.add(checkbox, 1, order);
+
+        default: /* GENERIC */
+          final Label genLabel = new Label(param.getName());
+          Text text3 = new Text(Constants.ASTRIKE);
+          text3.setFill(Color.RED);
+          genLabel.setStyle("-fx-background-color: #efeeee;");
+          HBox hb3 = new HBox();
+          hb3.getChildren().add(genLabel);
+          if (param.isOptional()) {
+            hb3.getChildren().add(blankText);
+          } else {
+            this.mandatoryParamList.add(param.getName());
+            hb3.getChildren().add(text3);
+          }
+          grid.add(hb3, 0, order);
+
+          TextField userTextField = new TextField();
+          userTextField.setMinHeight(Constants.HEIGHT);
+          userTextField.setMaxWidth(Constants.WIDTH);
+          userTextField.setId("text_" + param.getName());
+          userTextField.setTooltip(toolTip);
+          userTextField.setPromptText("Enter " + param.getName());
+          grid.add(userTextField, 1, order);
 
       }
 

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/Devon4j.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/Devon4j.java
@@ -413,15 +413,18 @@ public class Devon4j extends AbstractCommandModule {
    * Migrates an oasp4j or devon4j project to the latest version.
    *
    * @param projectPath the path of the project to migrate.
+   * @param singleVersion - {@code true} to only migrate to the next version, {@code false} otherwise (migrate to latest
+   *        version).
    */
-  @Command(name = "migrate", description = "This command will migrate the project to latest version", context = ContextType.PROJECT)
+  @Command(name = "migrate", description = "This command will migrate the project to latest version")
   @Parameters(values = {
-  @Parameter(name = "projectPath", description = "Path to project folder", optional = false, inputType = @InputType(name = InputTypeNames.PATH)), })
-  public void migrate(String projectPath) {
+  @Parameter(name = "projectPath", description = "Path to project folder", optional = false, inputType = @InputType(name = InputTypeNames.PATH)),
+  @Parameter(name = "singleVersion", description = "Migrate only to next version (rather than the latest version)", optional = true, inputType = @InputType(name = InputTypeNames.BOOLEAN)), })
+  public void migrate(String projectPath, String singleVersion) {
 
     try {
       Migrator migrator = Migrations.devon4j(getOutput());
-      migrator.migrate(new File(projectPath));
+      migrator.migrate(new File(projectPath), "true".equals(singleVersion));
     } catch (Exception e) {
       getOutput().showError("Migration failed.", e.getMessage());
       e.printStackTrace();

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/Devon4j.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/Devon4j.java
@@ -80,7 +80,7 @@ public class Devon4j extends AbstractCommandModule {
    * @param version Version of the Server Project
    * @throws Exception
    */
-  @Command(name = "create", description = "This creates a new server project based on OASP template")
+  @Command(name = "create", description = "This creates a new server project based on DEVON template")
   @Parameters(values = {
   @Parameter(name = "serverpath", description = "where to create", optional = true, inputType = @InputType(name = InputTypeNames.PATH)),
   @Parameter(name = "servername", description = "Name of project"),
@@ -93,17 +93,17 @@ public class Devon4j extends AbstractCommandModule {
 
     serverpath = serverpath.isEmpty() ? getContextPathInfo().getCurrentWorkingDirectory().toString() : serverpath;
 
-    String oaspTemplateVersion = Utils.getTemplateVersion(
+    String devonTemplateVersion = Utils.getTemplateVersion(
         Utils.addTrailingSlash(Utils.removeEndingDot(serverpath)) + Constants.VERSION_PARAMS_FILE_FULL_PATH);
-    if (oaspTemplateVersion.isEmpty())
+    if (devonTemplateVersion.isEmpty())
       this.output.showError(
-          "Oasp template version not found neither in config file '{devonfwPath}/conf/version.json' nor Internet. Please, go online or setup the config file correctly.");
+          "Devon template version not found neither in config file '{devonfwPath}/conf/version.json' nor Internet. Please, go online or setup the config file correctly.");
 
-    this.output.showMessage("Using the oasp template version: " + oaspTemplateVersion);
+    this.output.showMessage("Using the devon template version: " + devonTemplateVersion);
 
-    String baseCommand = new StringBuffer("mvn -DarchetypeVersion=").append(oaspTemplateVersion)
-        .append(" -DarchetypeGroupId=").append(Constants.OASP_TEMPLATE_GROUP_ID).append(" -DarchetypeArtifactId=")
-        .append(Constants.OASP_ARTIFACT_ID).append(" archetype:generate -DgroupId=").append(groupid)
+    String baseCommand = new StringBuffer("mvn -DarchetypeVersion=").append(devonTemplateVersion)
+        .append(" -DarchetypeGroupId=").append(Constants.DEVON_TEMPLATE_GROUP_ID).append(" -DarchetypeArtifactId=")
+        .append(Constants.DEVON_ARTIFACT_ID).append(" archetype:generate -DgroupId=").append(groupid)
         .append(" -DartifactId=").append(servername).append(" -Dversion=").append(version).append(" -Dpackage=")
         .append(packagename).append(" -DdbType=").append(dbtype).append(" -DinteractiveMode=false").toString();
 
@@ -140,12 +140,12 @@ public class Devon4j extends AbstractCommandModule {
           getOutput().showMessage("Adding devon.json file...");
           Utils.addDevonJsonFile(project.toPath(), ProjectType.DEVON4J);
 
-          if (Integer.parseInt(oaspTemplateVersion.replaceAll("\\.", "")) <= new Integer("211")) {
+          if (Integer.parseInt(devonTemplateVersion.replaceAll("\\.", "")) <= new Integer("211")) {
             modifyPom(serverpath + File.separator + servername + File.separator + "server" + File.separator + "pom.xml",
                 packagename);
           }
 
-          getOutput().showMessage("devonp4j project created successfully");
+          getOutput().showMessage("devon4j project created successfully");
 
         } else {
           throw new Exception("Project creation failed");
@@ -211,7 +211,7 @@ public class Devon4j extends AbstractCommandModule {
 
     } catch (Exception e) {
 
-      getOutput().showError("An error occured during executing devonp4j Cmd: %s", e.getMessage());
+      getOutput().showError("An error occured during executing devon4j Cmd: %s", e.getMessage());
     }
   }
 
@@ -245,7 +245,7 @@ public class Devon4j extends AbstractCommandModule {
       Utils.processOutput(isError, isOutput, this.output);
 
     } catch (Exception e) {
-      getOutput().showError("An error occured during executing devonp4j Cmd" + e.getMessage());
+      getOutput().showError("An error occured during executing devon4j Cmd" + e.getMessage());
     }
   }
 
@@ -411,7 +411,7 @@ public class Devon4j extends AbstractCommandModule {
       }
 
     } catch (Exception e) {
-      getOutput().showError("In devonp4j deploy command. " + e.getMessage());
+      getOutput().showError("In devon4j deploy command. " + e.getMessage());
     }
   }
 
@@ -516,7 +516,7 @@ public class Devon4j extends AbstractCommandModule {
       }
 
     } catch (Exception e) {
-      getOutput().showError("Error executing devonp4j command " + e.getMessage());
+      getOutput().showError("Error executing devon4j command " + e.getMessage());
 
     }
 

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/Devon4j.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/Devon4j.java
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************/
-package com.devonfw.devcon.modules.oasp4j;
+package com.devonfw.devcon.modules.devon4j;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -57,17 +57,17 @@ import com.devonfw.devcon.common.utils.Utils;
 import com.google.common.base.Optional;
 
 /**
- * This class implements a Command Module with Oasp4j(server project) related commands
+ * This class implements a Command Module with Devon4j(server project) related commands
  *
  * @author ssarmoka
  */
 @CmdModuleRegistry(name = "devon4j", description = "Devon4j(server project) related commands", sort = 3)
-public class Oasp4j extends AbstractCommandModule {
+public class Devon4j extends AbstractCommandModule {
 
   /**
    * The constructor.
    */
-  public Oasp4j() {
+  public Devon4j() {
 
     super();
   }
@@ -163,7 +163,7 @@ public class Oasp4j extends AbstractCommandModule {
   }
 
   /**
-   * Run OASP4j Project from the command line ContextType Project makes this into a "special" command which gets an
+   * Run DEVON4J Project from the command line ContextType Project makes this into a "special" command which gets an
    * extra parameter '-path' allowing to specify the project root (in reality, any directory below the root is valid as
    * well) Alternatively, the current dir is used. When the file devon.json is found at the project root, it is
    * available as type ProjectInfo in the field propertyInfo. Apart from "version" and "type" (default properties) *ANY*

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -37,6 +37,9 @@ public class Migrations {
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
         .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
         .replaceRegex("\\s*\\$\\{oasp4j\\.version\\}\\s*", "\\$\\{devon4j.version\\}") //
+        .replaceProperty("oasp.test.excluded.groups", null, "devonfw.test.excluded.groups") //
+        .replaceRegex("\\s*\\$\\{oasp\\.test\\.excluded\\.groups\\}\\s*", "\\$\\{devonfw.test.excluded.groups\\}") //
+        .replaceRegex("io\\.oasp\\.module\\.test\\.", "com.devonfw.module.test.") //
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J, "oasp4j-bom", null),
             new VersionIdentifier(VersionIdentifier.GROUP_ID_DEVON4J_BOMS, "devon4j-bom", null))
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J + "*", "oasp4j*", null),

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -35,8 +35,8 @@ public class Migrations {
         .applicationProperties().replace("flyway.", "spring.flyway.").and().next() //
 
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
-        .pom().replaceProperty("oasp4j.version", "3.0.0-SNAPSHOT", "devon4j.version") //
-        .replaceString("${oasp4j.version}", "${devon4j.version}") //
+        .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
+        .replaceRegex("\\s*\\$\\{oasp4j\\.version\\}\\s*", "\\$\\{devon4j.version\\}") //
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J, "oasp4j-bom", null),
             new VersionIdentifier(VersionIdentifier.GROUP_ID_DEVON4J_BOMS, "devon4j-bom", null))
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J + "*", "oasp4j*", null),

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -23,21 +23,35 @@ public class Migrations {
         .pom().replaceProperty("oasp4j.version", "2.6.1").and().next() //
 
         .to(VersionIdentifier.ofOasp4j("3.0.0")) //
-        .pom().replaceProperty("oasp4j.version", "3.0.0").and() //
+        .pom().replaceProperty("oasp4j.version", "3.0.0") //
+        .replaceProperty("spring.boot.version", "2.0.4.RELEASE") //
+        .replaceProperty("flyway.version", "5.0.7") //
+        .replaceDependency(new VersionIdentifier("org.hibernate", "hibernate-validator", null),
+            new VersionIdentifier("org.hibernate.validator", "hibernate-validator", null))
+        .and() //
         .java().replace("org.hibernate.Query", "org.hibernate.query.Query")
         .replace("com.mysema.query.alias.Alias", "com.querydsl.core.alias.Alias")
         .replace("com.mysema.query.jpa.impl.JPAQuery", "com.querydsl.jpa.impl.JPAQuery")
         .replace("com.mysema.query.types.path.EntityPathBase", "com.querydsl.core.types.dsl.EntityPathBase")
+        .replace("org.springframework.boot.web.support.SpringBootServletInitializer",
+            "org.springframework.boot.web.servlet.support.SpringBootServletInitializer")
+        .replace("org.springframework.boot.context.embedded.LocalServerPort",
+            "org.springframework.boot.web.server.LocalServerPort")
+        .replace("org.springframework.boot.actuate.autoconfigure.EndpointAutoConfiguration",
+            "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration")
+        .replace("org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration",
+            "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration")
+        .replace("org.springframework.boot.autoconfigure.security.SecurityFilterAutoConfiguration",
+            "org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration")
         .replace("query.clone().count()", "query.clone().fetchCount()").replace("query.count()", "query.fetchCount()")
         .replace("query.list(expr)", "query.select(expr).fetch()").replace("query.list()", "query.fetch()")
         .replace("query.firstResult(", "query.fetchFirst(").replace("query.uniqueResult(", "query.fetchUnique(")
         .replace("query.listResults(", "query.fetchResults(").add(new QueryDslJpaQueryLineMigration()).and() //
-        .applicationProperties().replace("flyway.", "spring.flyway.").and().next() //
+        .applicationProperties().replace("flyway.", "spring.flyway.") //
+        .replace("server.context-path", "server.servlet.context-path").and().next() //
 
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
         .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
-        .replaceProperty("spring.boot.version", "2.0.4.RELEASE") //
-        .replaceProperty("flyway.version", "5.0.7") //
         .replaceRegex("\\s*\\$\\{oasp4j\\.version\\}\\s*", "\\$\\{devon4j.version\\}") //
         .replaceProperty("oasp.test.excluded.groups", null, "devonfw.test.excluded.groups") //
         .replaceRegex("\\s*\\$\\{oasp\\.test\\.excluded\\.groups\\}\\s*", "\\$\\{devonfw.test.excluded.groups\\}") //

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -36,6 +36,8 @@ public class Migrations {
 
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
         .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
+        .replaceProperty("spring.boot.version", "2.0.4.RELEASE") //
+        .replaceProperty("flyway.version", "5.0.7") //
         .replaceRegex("\\s*\\$\\{oasp4j\\.version\\}\\s*", "\\$\\{devon4j.version\\}") //
         .replaceProperty("oasp.test.excluded.groups", null, "devonfw.test.excluded.groups") //
         .replaceRegex("\\s*\\$\\{oasp\\.test\\.excluded\\.groups\\}\\s*", "\\$\\{devonfw.test.excluded.groups\\}") //

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/Migrations.java
@@ -1,6 +1,8 @@
 package com.devonfw.devcon.modules.devon4j.migrate;
 
 import com.devonfw.devcon.modules.devon4j.migrate.builder.MigrationBuilder;
+import com.devonfw.devcon.modules.devon4j.migrate.file.FileFilterPattern;
+import com.devonfw.devcon.modules.devon4j.migrate.line.QueryDslJpaQueryLineMigration;
 import com.devonfw.devcon.modules.devon4j.migrate.version.VersionIdentifier;
 import com.devonfw.devcon.output.Output;
 
@@ -24,17 +26,40 @@ public class Migrations {
         .pom().replaceProperty("oasp4j.version", "3.0.0").and() //
         .java().replace("org.hibernate.Query", "org.hibernate.query.Query")
         .replace("com.mysema.query.alias.Alias", "com.querydsl.core.alias.Alias")
-        .replace("com.mysema.query.jpa.impl.JPAQuery", "com.querydsl.jpa.impl.JPAQuery").and() //
+        .replace("com.mysema.query.jpa.impl.JPAQuery", "com.querydsl.jpa.impl.JPAQuery")
+        .replace("com.mysema.query.types.path.EntityPathBase", "com.querydsl.core.types.dsl.EntityPathBase")
+        .replace("query.clone().count()", "query.clone().fetchCount()").replace("query.count()", "query.fetchCount()")
+        .replace("query.list(expr)", "query.select(expr).fetch()").replace("query.list()", "query.fetch()")
+        .replace("query.firstResult(", "query.fetchFirst(").replace("query.uniqueResult(", "query.fetchUnique(")
+        .replace("query.listResults(", "query.fetchResults(").add(new QueryDslJpaQueryLineMigration()).and() //
         .applicationProperties().replace("flyway.", "spring.flyway.").and().next() //
 
         .to(VersionIdentifier.ofDevon4j("3.0.0")) //
-        .pom().replaceProperty("oasp4j.version", "3.0.0", "devon4j.version") //
+        .pom().replaceProperty("oasp4j.version", "3.0.0-SNAPSHOT", "devon4j.version") //
         .replaceString("${oasp4j.version}", "${devon4j.version}") //
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J, "oasp4j-bom", null),
             new VersionIdentifier(VersionIdentifier.GROUP_ID_DEVON4J_BOMS, "devon4j-bom", null))
         .replaceDependency(new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J + "*", "oasp4j*", null),
             new VersionIdentifier(VersionIdentifier.GROUP_ID_DEVON4J + "*", "devon4j*", null))
-        .and().java()
+        .addDependency(new VersionIdentifier(null, "*-api", null),
+            new VersionIdentifier(VersionIdentifier.GROUP_ID_OASP4J_MODULES, "oasp4j-jpa", "3.0.0"))
+        .and().java() //
+        .replace("io.oasp.module.rest.service.impl.json.ObjectMapperFactory",
+            "com.devonfw.module.json.common.base.ObjectMapperFactory")
+        .replace("io.oasp.module.jpa.dataaccess.api.MutablePersistenceEntity",
+            "com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity")
+        .replace("ApplicationPersistenceEntity implements ApplicationEntity, MutablePersistenceEntity<Long>",
+            "ApplicationPersistenceEntity implements ApplicationEntity, RevisionedPersistenceEntity<Long>")
+        .replace("ApplicationDao<ENTITY extends MutablePersistenceEntity<Long>>",
+            "ApplicationDao<ENTITY extends com.devonfw.module.basic.common.api.entity.PersistenceEntity<Long>>")
+        .replace("ApplicationRevisionedDao<ENTITY extends MutablePersistenceEntity<Long>>",
+            "ApplicationRevisionedDao<ENTITY extends RevisionedPersistenceEntity<Long>>")
+        .replace("DaoImpl<ENTITY extends MutablePersistenceEntity<Long>>",
+            "DaoImpl<ENTITY extends RevisionedPersistenceEntity<Long>>")
+        .replace("MutablePersistenceEntity", "RevisionedPersistenceEntity")
+        .replace("io.oasp.module.jpa.common.api.to.", "hack.oasp.module.jpa.common.api.to.")
+        .replace("io.oasp.module.", "com.devonfw.module.")
+        .replace("hack.oasp.module.jpa.common.api.to.", "io.oasp.module.jpa.common.api.to.")
         .replace("net.sf.mmm.util.entity.api.GenericEntity", "com.devonfw.module.basic.common.api.entity.GenericEntity")
         .replace("net.sf.mmm.util.entity.api.RevisionedEntity",
             "com.devonfw.module.basic.common.api.entity.RevisionedEntity")
@@ -42,7 +67,30 @@ public class Migrations {
             "com.devonfw.module.basic.common.api.entity.RevisionedEntity")
         .replace("net.sf.mmm.util.entity.api.PersistenceEntity",
             "com.devonfw.module.basic.common.api.entity.PersistenceEntity")
+        .replace("net.sf.mmm.util.entity.api.MutableGenericEntity",
+            "com.devonfw.module.basic.common.api.entity.GenericEntity")
+        .replace("net.sf.mmm.util.transferobject.api.CompositeTo", "com.devonfw.module.basic.common.api.to.AbstractCto")
+        .replace("net.sf.mmm.util.transferobject.api.AbstractTransferObject",
+            "com.devonfw.module.basic.common.api.to.AbstractTo")
+        .replace("net.sf.mmm.util.transferobject.api.TransferObject",
+            "com.devonfw.module.basic.common.api.to.AbstractTo")
+        .replace("TransferObject", "AbstractTo")
+        .replace("AbstractCto extends CompositeTo",
+            "AbstractCto extends com.devonfw.module.basic.common.api.to.AbstractCto")
+        .replace("CompositeTo", "AbstractCto")
+        .replace("AbstractEto extends EntityTo<Long>",
+            "AbstractEto extends com.devonfw.module.basic.common.api.to.AbstractEto")
+        .replace("EntityTo<Long>", "AbstractEto").replace("MutableGenericEntity<", "GenericEntity<")
         .replace("net.sf.mmm.util.transferobject.api.EntityTo", "com.devonfw.module.basic.common.api.to.AbstractEto")
+        .replace(".OaspPackage", ".Devon4jPackage").replace("OaspPackage ", "Devon4jPackage ")
+        .replace("OaspPackage.", "Devon4jPackage.")
+        .replace("import com.devonfw.module.basic.common.api.to.AbstractEto;", "",
+            FileFilterPattern.accept("AbstractEto\\.java"))
+        .replace("import com.devonfw.module.basic.common.api.to.AbstractCto;", "",
+            FileFilterPattern.accept("AbstractCto\\.java"))
+        .replaceRegex("implements ([a-zA-Z0-9_]*)Dao",
+            "implements $1Dao, io.oasp.module.jpa.common.base.LegacyDaoQuerySupport<$1Entity>",
+            FileFilterPattern.reject("Application(MasterData)?DaoImpl\\.java")) //
         .and() //
         .next().build();
   }

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/MigrationStepBuilder.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/MigrationStepBuilder.java
@@ -1,5 +1,7 @@
 package com.devonfw.devcon.modules.devon4j.migrate.builder;
 
+import java.util.regex.Pattern;
+
 import com.devonfw.devcon.modules.devon4j.migrate.MigrationStep;
 import com.devonfw.devcon.modules.devon4j.migrate.MigrationStepImpl;
 import com.devonfw.devcon.modules.devon4j.migrate.file.TextFileMigration;
@@ -10,7 +12,7 @@ import com.devonfw.devcon.modules.devon4j.migrate.version.VersionIdentifier;
  */
 public class MigrationStepBuilder {
 
-  private final MigrationBuilder parent;
+  final MigrationBuilder parent;
 
   final MigrationStepImpl step;
 
@@ -53,6 +55,17 @@ public class MigrationStepBuilder {
   public PomXmlMigrationBuilder pom() {
 
     return new PomXmlMigrationBuilder(this);
+  }
+
+  /**
+   * @param filename the filename to match literally.
+   * @return a new builder to create an XML migration. Call {@link XmlMigrationBuilder#and()} to continue with this
+   *         builder once complete.
+   */
+  public XmlMigrationBuilder xml(String filename) {
+
+    Pattern pattern = Pattern.compile(filename.replace(".", "\\."));
+    return new XmlMigrationBuilder(this, pattern);
   }
 
   /**

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/PomXmlMigrationBuilder.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/PomXmlMigrationBuilder.java
@@ -2,6 +2,7 @@ package com.devonfw.devcon.modules.devon4j.migrate.builder;
 
 import com.devonfw.devcon.modules.devon4j.migrate.file.XmlFileMigration;
 import com.devonfw.devcon.modules.devon4j.migrate.version.VersionIdentifier;
+import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenDependencyAdder;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenDependencyReplacement;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenPropertyReplacement;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.XmlStringReplacement;
@@ -29,6 +30,17 @@ public class PomXmlMigrationBuilder extends XmlMigrationBuilder {
   public PomXmlMigrationBuilder replaceDependency(VersionIdentifier pattern, VersionIdentifier replacement) {
 
     this.migration.getMigrations().add(new MavenDependencyReplacement(pattern, replacement));
+    return this;
+  }
+
+  /**
+   * @param projectPattern the {@link VersionIdentifier} of the maven project/module to match.
+   * @param dependency the {@link VersionIdentifier} with the dependency to add.
+   * @return {@code this}.
+   */
+  public PomXmlMigrationBuilder addDependency(VersionIdentifier projectPattern, VersionIdentifier dependency) {
+
+    this.migration.getMigrations().add(new MavenDependencyAdder(projectPattern, dependency));
     return this;
   }
 

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/PomXmlMigrationBuilder.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/PomXmlMigrationBuilder.java
@@ -1,10 +1,13 @@
 package com.devonfw.devcon.modules.devon4j.migrate.builder;
 
+import java.util.regex.Pattern;
+
 import com.devonfw.devcon.modules.devon4j.migrate.file.XmlFileMigration;
 import com.devonfw.devcon.modules.devon4j.migrate.version.VersionIdentifier;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenDependencyAdder;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenDependencyReplacement;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.MavenPropertyReplacement;
+import com.devonfw.devcon.modules.devon4j.migrate.xml.XmlRegexReplacement;
 import com.devonfw.devcon.modules.devon4j.migrate.xml.XmlStringReplacement;
 
 /**
@@ -74,6 +77,27 @@ public class PomXmlMigrationBuilder extends XmlMigrationBuilder {
   public PomXmlMigrationBuilder replaceString(String search, String replacement) {
 
     this.migration.getMigrations().add(new XmlStringReplacement(search, replacement));
+    return this;
+  }
+
+  /**
+   * @param pattern the plain {@link Pattern} to replace in POM.
+   * @param replacement the replacement {@link String}.
+   * @return {@code this}.
+   */
+  public PomXmlMigrationBuilder replaceRegex(String pattern, String replacement) {
+
+    return replaceRegex(Pattern.compile(pattern), replacement);
+  }
+
+  /**
+   * @param pattern the plain {@link Pattern} to replace in POM.
+   * @param replacement the replacement {@link String}.
+   * @return {@code this}.
+   */
+  public PomXmlMigrationBuilder replaceRegex(Pattern pattern, String replacement) {
+
+    this.migration.getMigrations().add(new XmlRegexReplacement(pattern, replacement));
     return this;
   }
 

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/TextFileMigrationBuilder.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/TextFileMigrationBuilder.java
@@ -1,8 +1,11 @@
 package com.devonfw.devcon.modules.devon4j.migrate.builder;
 
+import java.io.FileFilter;
 import java.util.regex.Pattern;
 
+import com.devonfw.devcon.modules.devon4j.migrate.file.FileFilterAll;
 import com.devonfw.devcon.modules.devon4j.migrate.file.TextFileMigration;
+import com.devonfw.devcon.modules.devon4j.migrate.line.LineMigration;
 import com.devonfw.devcon.modules.devon4j.migrate.line.RegexLineMigration;
 import com.devonfw.devcon.modules.devon4j.migrate.line.StringReplaceLineMigration;
 
@@ -25,7 +28,7 @@ public class TextFileMigrationBuilder {
 
     super();
     this.parent = parent;
-    this.migration = new TextFileMigration(pattern);
+    this.migration = new TextFileMigration(parent.parent.output, pattern);
   }
 
   /**
@@ -36,7 +39,19 @@ public class TextFileMigrationBuilder {
    */
   public TextFileMigrationBuilder replaceRegex(Pattern pattern, String replacement) {
 
-    this.migration.getLineMigrations().add(new RegexLineMigration(pattern, replacement));
+    return replaceRegex(pattern, replacement, FileFilterAll.INSTANCE);
+  }
+
+  /**
+   * @param pattern the {@link Pattern} to match.
+   * @param replacement the replacement for the given {@link Pattern}. May contain variable expressions (e.g. "$1") to
+   *        reference regex groups.
+   * @param fileFilter the {@link FileFilter} to accept the files that shall be migrated.
+   * @return {@code this}.
+   */
+  public TextFileMigrationBuilder replaceRegex(Pattern pattern, String replacement, FileFilter fileFilter) {
+
+    this.migration.getLineMigrations().add(new RegexLineMigration(pattern, replacement, fileFilter));
     return this;
   }
 
@@ -48,8 +63,19 @@ public class TextFileMigrationBuilder {
    */
   public TextFileMigrationBuilder replaceRegex(String pattern, String replacement) {
 
-    this.migration.getLineMigrations().add(new RegexLineMigration(Pattern.compile(pattern), replacement));
-    return this;
+    return replaceRegex(Pattern.compile(pattern), replacement);
+  }
+
+  /**
+   * @param pattern the {@link Pattern} to match as {@link String}.
+   * @param replacement the replacement for the given {@link Pattern}. May contain variable expressions (e.g. "$1") to
+   *        reference regex groups.
+   * @param fileFilter the {@link FileFilter} to accept the files that shall be migrated.
+   * @return {@code this}.
+   */
+  public TextFileMigrationBuilder replaceRegex(String pattern, String replacement, FileFilter fileFilter) {
+
+    return replaceRegex(Pattern.compile(pattern), replacement, fileFilter);
   }
 
   /**
@@ -59,7 +85,28 @@ public class TextFileMigrationBuilder {
    */
   public TextFileMigrationBuilder replace(String search, String replacement) {
 
-    this.migration.getLineMigrations().add(new StringReplaceLineMigration(search, replacement));
+    return replace(search, replacement, FileFilterAll.INSTANCE);
+  }
+
+  /**
+   * @param search the plain {@link String} to search for.
+   * @param replacement the replacement for the given {@code search} {@link String}.
+   * @param fileFilter the {@link FileFilter} to accept the files that shall be migrated.
+   * @return {@code this}.
+   */
+  public TextFileMigrationBuilder replace(String search, String replacement, FileFilter fileFilter) {
+
+    this.migration.getLineMigrations().add(new StringReplaceLineMigration(search, replacement, fileFilter));
+    return this;
+  }
+
+  /**
+   * @param lineMigration the custom {@link LineMigration} to add.
+   * @return {@code this}.
+   */
+  public TextFileMigrationBuilder add(LineMigration lineMigration) {
+
+    this.migration.getLineMigrations().add(lineMigration);
     return this;
   }
 

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/XmlMigrationBuilder.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/builder/XmlMigrationBuilder.java
@@ -3,6 +3,7 @@ package com.devonfw.devcon.modules.devon4j.migrate.builder;
 import java.util.regex.Pattern;
 
 import com.devonfw.devcon.modules.devon4j.migrate.file.XmlFileMigration;
+import com.devonfw.devcon.modules.devon4j.migrate.xml.XmlStringReplacement;
 
 /**
  * Builder for an {@link XmlFileMigration}.
@@ -24,7 +25,18 @@ public class XmlMigrationBuilder {
 
     super();
     this.parent = parent;
-    this.migration = new XmlFileMigration(pattern);
+    this.migration = new XmlFileMigration(parent.parent.output, pattern);
+  }
+
+  /**
+   * @param search the {@link String} to search for.
+   * @param replacement the replacement for the given {@code search} {@link String}.
+   * @return {@code this}.
+   */
+  public XmlMigrationBuilder replaceText(String search, String replacement) {
+
+    this.migration.getMigrations().add(new XmlStringReplacement(search, replacement));
+    return this;
   }
 
   /**

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/FileFilterAll.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/FileFilterAll.java
@@ -1,0 +1,20 @@
+package com.devonfw.devcon.modules.devon4j.migrate.file;
+
+import java.io.File;
+import java.io.FileFilter;
+
+/**
+ * {@link FileFilter} {@link #accept(File) accepting} no {@link File}.
+ */
+public class FileFilterAll implements FileFilter {
+
+  /** Singleton instance. */
+  public static final FileFilterAll INSTANCE = new FileFilterAll();
+
+  @Override
+  public boolean accept(File pathname) {
+
+    return true;
+  }
+
+}

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/FileFilterNone.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/FileFilterNone.java
@@ -1,0 +1,20 @@
+package com.devonfw.devcon.modules.devon4j.migrate.file;
+
+import java.io.File;
+import java.io.FileFilter;
+
+/**
+ * {@link FileFilter} {@link #accept(File) accepting} all {@link File}s.
+ */
+public class FileFilterNone implements FileFilter {
+
+  /** Singleton instance. */
+  public static final FileFilterNone INSTANCE = new FileFilterNone();
+
+  @Override
+  public boolean accept(File pathname) {
+
+    return false;
+  }
+
+}

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/FileFilterPattern.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/FileFilterPattern.java
@@ -1,0 +1,59 @@
+package com.devonfw.devcon.modules.devon4j.migrate.file;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.regex.Pattern;
+
+/**
+ * {@link FileFilter} {@link #accept(File) accepting} only {@link File}s that (do not) match a given regxe.
+ */
+public class FileFilterPattern implements FileFilter {
+
+  private final Pattern pattern;
+
+  private final boolean result;
+
+  /**
+   * The constructor.
+   *
+   * @param pattern the {@link Pattern} to match.
+   * @param result the result of {@link #accept(File)} if the given {@link Pattern} matches.
+   */
+  public FileFilterPattern(Pattern pattern, boolean result) {
+
+    super();
+    this.pattern = pattern;
+    this.result = result;
+  }
+
+  @Override
+  public boolean accept(File file) {
+
+    String name = file.getName();
+    if (this.pattern.matcher(name).matches()) {
+      return this.result;
+    }
+    return !this.result;
+  }
+
+  /**
+   * @param regex the regex {@link Pattern} to match.
+   * @return the {@link FileFilterPattern} that {@link #accept(File) accepts} only files that have a
+   *         {@link File#getName() name} matching the given {@link Pattern}.
+   */
+  public static FileFilterPattern accept(String regex) {
+
+    return new FileFilterPattern(Pattern.compile(regex), true);
+  }
+
+  /**
+   * @param regex the regex {@link Pattern} to match.
+   * @return the {@link FileFilterPattern} that {@link #accept(File) accepts} only files that have a
+   *         {@link File#getName() name} <b>not</b> matching the given {@link Pattern}.
+   */
+  public static FileFilterPattern reject(String regex) {
+
+    return new FileFilterPattern(Pattern.compile(regex), false);
+  }
+
+}

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/FileMigration.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/FileMigration.java
@@ -4,23 +4,28 @@ import java.io.File;
 import java.util.regex.Pattern;
 
 import com.devonfw.devcon.modules.devon4j.migrate.Migration;
+import com.devonfw.devcon.output.Output;
 
 /**
  * {@link Migration} for a single {@link File}.
  */
 public abstract class FileMigration implements Migration {
 
-  private Pattern namePattern;
+  final Output output;
+
+  private final Pattern namePattern;
 
   /**
    * The constructor.
    *
+   * @param output the {@link Output}.
    * @param namePattern the {@link Pattern} used to match the {@link File#getName() filename} to apply this migration
    *        to.
    */
-  public FileMigration(Pattern namePattern) {
+  public FileMigration(Output output, Pattern namePattern) {
 
     super();
+    this.output = output;
     this.namePattern = namePattern;
   }
 

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/XmlFileMigration.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/file/XmlFileMigration.java
@@ -14,6 +14,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 
 import com.devonfw.devcon.modules.devon4j.migrate.xml.XmlMigration;
+import com.devonfw.devcon.output.Output;
 
 /**
  * Implementation of {@link FileMigration} for XML {@link File}.
@@ -28,11 +29,12 @@ public class XmlFileMigration extends FileMigration implements XmlMigration {
   /**
    * The constructor.
    *
+   * @param output the {@link Output}.
    * @param namePattern the {@link Pattern} to match the filename.
    */
-  public XmlFileMigration(Pattern namePattern) {
+  public XmlFileMigration(Output output, Pattern namePattern) {
 
-    super(namePattern);
+    super(output, namePattern);
     this.migrations = new ArrayList<>();
   }
 
@@ -42,6 +44,7 @@ public class XmlFileMigration extends FileMigration implements XmlMigration {
     Document xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file);
     boolean change = migrateXml(xml);
     if (change) {
+      this.output.showMessage("Migrating file: %s", file.getPath());
       Result target = new StreamResult(file);
       TransformerFactory.newInstance().newTransformer().transform(new DOMSource(xml), target);
     }

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/AbstractLineMigration.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/AbstractLineMigration.java
@@ -1,0 +1,54 @@
+package com.devonfw.devcon.modules.devon4j.migrate.line;
+
+import java.io.File;
+import java.io.FileFilter;
+
+/**
+ * Abstract base implementation of {@link LineMigration}.
+ */
+public abstract class AbstractLineMigration implements LineMigration {
+
+  private final FileFilter fileFilter;
+
+  private boolean disabled;
+
+  /**
+   * The constructor.
+   *
+   * @param fileFilter the {@link FileFilter} to accept the files that shall be migrated.
+   */
+  public AbstractLineMigration(FileFilter fileFilter) {
+
+    super();
+    this.fileFilter = fileFilter;
+  }
+
+  @Override
+  public void init(File file) {
+
+    this.disabled = !this.fileFilter.accept(file);
+  }
+
+  @Override
+  public final String migrateLine(String line) {
+
+    if (this.disabled) {
+      return line;
+    }
+    return migrate(line);
+  }
+
+  /**
+   * @see #migrateLine(String)
+   * @param line the line to migrate.
+   * @return the migrated line.
+   */
+  protected abstract String migrate(String line);
+
+  @Override
+  public void clear() {
+
+    this.disabled = false;
+  }
+
+}

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/LineMigration.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/LineMigration.java
@@ -1,14 +1,26 @@
 package com.devonfw.devcon.modules.devon4j.migrate.line;
 
+import java.io.File;
+
 /**
  * Interface to migrate a single line of text (code, etc.)
  */
 public interface LineMigration {
 
   /**
+   * @param file the {@link File} to start migrating.
+   */
+  void init(File file);
+
+  /**
    * @param line the line of text to process.
    * @return the migrated line (may be the original or a modified one).
    */
   String migrateLine(String line);
+
+  /**
+   * Called at the beginning of each new file to clear potential state.
+   */
+  void clear();
 
 }

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/QueryDslJpaQueryLineMigration.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/QueryDslJpaQueryLineMigration.java
@@ -1,0 +1,50 @@
+package com.devonfw.devcon.modules.devon4j.migrate.line;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.devonfw.devcon.modules.devon4j.migrate.file.FileFilterAll;
+
+/**
+ * Implementation of {@link LineMigration} for simple string replacement.
+ */
+public class QueryDslJpaQueryLineMigration extends AbstractLineMigration {
+
+  private static final Pattern ENTITY_NAME_PATTERN = Pattern.compile(".*<([a-zA-Z0-9]*Entity)>.*");
+
+  private String entityName;
+
+  private String replacement;
+
+  /**
+   * The constructor.
+   */
+  public QueryDslJpaQueryLineMigration() {
+
+    super(FileFilterAll.INSTANCE);
+  }
+
+  @Override
+  protected String migrate(String line) {
+
+    if (this.entityName == null) {
+      // kind of hackish but should do
+      Matcher matcher = ENTITY_NAME_PATTERN.matcher(line);
+      if (matcher.matches()) {
+        this.entityName = matcher.group(1);
+        this.replacement = "JPAQuery<" + this.entityName + ">";
+      }
+      return line;
+    } else {
+      return line.replace("JPAQuery", this.replacement);
+    }
+  }
+
+  @Override
+  public void clear() {
+
+    this.entityName = null;
+    this.replacement = null;
+  }
+
+}

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/RegexLineMigration.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/RegexLineMigration.java
@@ -1,11 +1,12 @@
 package com.devonfw.devcon.modules.devon4j.migrate.line;
 
+import java.io.FileFilter;
 import java.util.regex.Pattern;
 
 /**
  * Implementation of {@link LineMigration} based on regex {@link Pattern} replacement.
  */
-public class RegexLineMigration implements LineMigration {
+public class RegexLineMigration extends AbstractLineMigration {
 
   private final Pattern regex;
 
@@ -13,19 +14,20 @@ public class RegexLineMigration implements LineMigration {
 
   /**
    * The constructor.
-   * 
+   *
    * @param regex the {@link Pattern} to match.
    * @param replacement the replacement.
+   * @param fileFilter the {@link FileFilter} to accept the files that shall be migrated.
    */
-  public RegexLineMigration(Pattern regex, String replacement) {
+  public RegexLineMigration(Pattern regex, String replacement, FileFilter fileFilter) {
 
-    super();
+    super(fileFilter);
     this.regex = regex;
     this.replacement = replacement;
   }
 
   @Override
-  public String migrateLine(String line) {
+  protected String migrate(String line) {
 
     return this.regex.matcher(line).replaceAll(this.replacement);
   }

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/StringReplaceLineMigration.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/line/StringReplaceLineMigration.java
@@ -1,9 +1,11 @@
 package com.devonfw.devcon.modules.devon4j.migrate.line;
 
+import java.io.FileFilter;
+
 /**
  * Implementation of {@link LineMigration} for simple string replacement.
  */
-public class StringReplaceLineMigration implements LineMigration {
+public class StringReplaceLineMigration extends AbstractLineMigration {
 
   private final String search;
 
@@ -14,16 +16,17 @@ public class StringReplaceLineMigration implements LineMigration {
    *
    * @param search the {@link String} to search for.
    * @param replacement the replacement for the {@code search} {@link String}.
+   * @param fileFilter the {@link FileFilter} to accept the files that shall be migrated.
    */
-  public StringReplaceLineMigration(String search, String replacement) {
+  public StringReplaceLineMigration(String search, String replacement, FileFilter fileFilter) {
 
-    super();
+    super(fileFilter);
     this.search = search;
     this.replacement = replacement;
   }
 
   @Override
-  public String migrateLine(String line) {
+  protected String migrate(String line) {
 
     return line.replace(this.search, this.replacement);
   }

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/version/VersionIdentifier.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/version/VersionIdentifier.java
@@ -123,6 +123,12 @@ public class VersionIdentifier {
       }
       String prefix = pattern.substring(0, pattern.length() - 1);
       return value.startsWith(prefix);
+    } else if (pattern.startsWith("*")) {
+      if (value == null) {
+        return pattern.length() == 1;
+      }
+      String suffix = pattern.substring(1);
+      return value.endsWith(suffix);
     } else {
       return (pattern.equals(value));
     }

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/AbstractXmlSupport.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/AbstractXmlSupport.java
@@ -1,0 +1,58 @@
+package com.devonfw.devcon.modules.devon4j.migrate.xml;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Base class providing simple XML DOM functionality.
+ */
+public abstract class AbstractXmlSupport {
+
+  /**
+   * @param element the {@link Element} to modify.
+   * @param text the new {@link Element#setTextContent(String) text content}.
+   */
+  protected void setText(Element element, String text) {
+
+    if ((element != null) && (text != null)) {
+      element.setTextContent(text);
+    }
+  }
+
+  /**
+   * @param element the {@link Element} to read from.
+   * @return the {@link Element#getTextContent() text content} of the given {@link Element}.
+   */
+  protected String getText(Element element) {
+
+    if (element == null) {
+      return null;
+    }
+    return element.getTextContent();
+  }
+
+  /**
+   * @param parent the {@link Element} to read from.
+   * @param tag the {@link Element#getTagName() tag name} of the requested child.
+   * @return the (first) child of the given {@link Element} with the given tag.
+   */
+  protected Element getChildElement(Element parent, String tag) {
+
+    if (parent == null) {
+      return null;
+    }
+    NodeList childNodes = parent.getChildNodes();
+    for (int i = 0; i < childNodes.getLength(); i++) {
+      Node node = childNodes.item(i);
+      if (node.getNodeType() == Node.ELEMENT_NODE) {
+        Element element = (Element) node;
+        if (element.getTagName().equals(tag)) {
+          return element;
+        }
+      }
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/MavenDependencyAdder.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/MavenDependencyAdder.java
@@ -1,0 +1,69 @@
+package com.devonfw.devcon.modules.devon4j.migrate.xml;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.devonfw.devcon.modules.devon4j.migrate.version.VersionIdentifier;
+
+/**
+ * Implementation of {@link XmlMigration} for adding a maven dependency.
+ */
+public class MavenDependencyAdder extends AbstractXmlMigration {
+
+  private final VersionIdentifier projectPattern;
+
+  private final VersionIdentifier dependency;
+
+  /**
+   * The constructor.
+   *
+   * @param projectPattern the {@link VersionIdentifier} of the maven project/module to match.
+   * @param dependency the {@link VersionIdentifier} with the dependency to add.
+   */
+  public MavenDependencyAdder(VersionIdentifier projectPattern, VersionIdentifier dependency) {
+
+    super();
+    this.projectPattern = projectPattern;
+    this.dependency = dependency;
+  }
+
+  @Override
+  public boolean migrateXml(Document xml) throws Exception {
+
+    Element projectElement = xml.getDocumentElement();
+    Element artifactIdElement = getChildElement(projectElement, "artifactId");
+    String artifactId = getText(artifactIdElement);
+    Element groupIdElement = getChildElement(projectElement, "groupId");
+    String groupId = getText(groupIdElement);
+    if (groupId == null) {
+      Element parentElement = getChildElement(projectElement, "parent");
+      groupIdElement = getChildElement(parentElement, "groupId");
+      groupId = getText(groupIdElement);
+    }
+    Element versionElement = getChildElement(projectElement, "version");
+    String version = getText(versionElement);
+    VersionIdentifier vi = new VersionIdentifier(groupId, artifactId, version);
+    if (this.projectPattern.matches(vi)) {
+      Element dependenciesElement = getChildElement(projectElement, "dependencies");
+      if (dependenciesElement != null) {
+        Element dependencyElement = xml.createElement("dependency");
+        Element dependencyGroupIdElement = xml.createElement("groupId");
+        dependencyGroupIdElement.setTextContent(this.dependency.getGroupId());
+        dependencyElement.appendChild(dependencyGroupIdElement);
+        Element dependencyArtifactIdElement = xml.createElement("artifactId");
+        dependencyArtifactIdElement.setTextContent(this.dependency.getArtifactId());
+        dependencyElement.appendChild(dependencyArtifactIdElement);
+        String dependencyVersion = this.dependency.getVersion();
+        if (dependencyVersion != null) {
+          Element dependencyVersionElement = xml.createElement("version");
+          dependencyVersionElement.setTextContent(dependencyVersion);
+          dependencyElement.appendChild(dependencyVersionElement);
+        }
+        dependenciesElement.appendChild(dependencyElement);
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/XmlRegexReplacement.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/XmlRegexReplacement.java
@@ -1,6 +1,5 @@
 package com.devonfw.devcon.modules.devon4j.migrate.xml;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.w3c.dom.Document;
@@ -53,9 +52,10 @@ public class XmlRegexReplacement extends AbstractXmlMigration {
         }
       } else if (nodeType == Node.TEXT_NODE) {
         Text text = (Text) node;
-        Matcher matcher = this.pattern.matcher(text.getData());
-        if (matcher.matches()) {
-          text.setData(matcher.replaceAll(this.replacement));
+        String data = text.getData();
+        String newData = data.replaceAll(this.pattern.pattern(), this.replacement);
+        if (!data.equals(newData)) {
+          text.setData(newData);
           updated = true;
         }
       }

--- a/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/XmlRegexReplacement.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4j/migrate/xml/XmlRegexReplacement.java
@@ -1,0 +1,66 @@
+package com.devonfw.devcon.modules.devon4j.migrate.xml;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+
+/**
+ * Implementation of {@link AbstractXmlMigration} for a simple {@link String} replacement in any
+ * {@link Element#getTextContent() text}. Currently no attributes are supported as focus is so far on maven that does
+ * not make use of attributes.
+ */
+public class XmlRegexReplacement extends AbstractXmlMigration {
+
+  private Pattern pattern;
+
+  private String replacement;
+
+  /**
+   * The constructor.
+   *
+   * @param pattern the {@link Pattern} to search for.
+   * @param replacement the replacement for the given {@code search} {@link String}.
+   */
+  public XmlRegexReplacement(Pattern pattern, String replacement) {
+
+    super();
+    this.pattern = pattern;
+    this.replacement = replacement;
+  }
+
+  @Override
+  public boolean migrateXml(Document xml) throws Exception {
+
+    return migrateXmlElement(xml.getDocumentElement());
+  }
+
+  private boolean migrateXmlElement(Element element) {
+
+    boolean updated = false;
+    NodeList childNodes = element.getChildNodes();
+    for (int i = 0; i < childNodes.getLength(); i++) {
+      Node node = childNodes.item(i);
+      short nodeType = node.getNodeType();
+      if (nodeType == Node.ELEMENT_NODE) {
+        boolean childUpdated = migrateXmlElement((Element) node);
+        if (childUpdated) {
+          updated = true;
+        }
+      } else if (nodeType == Node.TEXT_NODE) {
+        Text text = (Text) node;
+        Matcher matcher = this.pattern.matcher(text.getData());
+        if (matcher.matches()) {
+          text.setData(matcher.replaceAll(this.replacement));
+          updated = true;
+        }
+      }
+    }
+    return updated;
+  }
+
+}

--- a/src/main/java/com/devonfw/devcon/modules/devon4ng/Devon4ng.java
+++ b/src/main/java/com/devonfw/devcon/modules/devon4ng/Devon4ng.java
@@ -1,19 +1,19 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************/
-package com.devonfw.devcon.modules.oasp4js;
+package com.devonfw.devcon.modules.devon4ng;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -36,13 +36,13 @@ import com.devonfw.devcon.common.utils.Utils;
 import com.google.common.base.Optional;
 
 /**
- * Module with tasks related to oasp4js (Angular client)
+ * Module with tasks related to devon4ng (Angular client)
  *
  * @author pparrado
  */
 
-@CmdModuleRegistry(name = "oasp4js", description = "Module to automate tasks related to oasp4js")
-public class Oasp4js extends AbstractCommandModule {
+@CmdModuleRegistry(name = "devon4ng", description = "Module to automate tasks related to devon4ng")
+public class Devon4ng extends AbstractCommandModule {
 
   private static String[] STATE = { "successfully", "failed" };
 
@@ -52,7 +52,7 @@ public class Oasp4js extends AbstractCommandModule {
 
   private static String NG_SERVE = " ng serve --progress false";
 
-  @Command(name = "create", description = "This command creates a basic Oasp4js app")
+  @Command(name = "create", description = "This command creates a basic Devon4ng app")
   @Parameters(values = { @Parameter(name = "clientname", description = "The name for the project"),
   @Parameter(name = "clientpath", description = "The location for the new project", optional = true, inputType = @InputType(name = InputTypeNames.PATH)) })
   public void create(String clientname, String clientpath) {
@@ -96,7 +96,7 @@ public class Oasp4js extends AbstractCommandModule {
           int result = process.waitFor();
           if (result == 0) {
             getOutput().showMessage("Adding devon.json file...");
-            Utils.addDevonJsonFile(projectFile.toPath(), ProjectType.OASP4JS);
+            Utils.addDevonJsonFile(projectFile.toPath(), ProjectType.DEVON4NG);
           }
 
           getOutput().showMessage("Project create " + STATE[result]);
@@ -111,7 +111,7 @@ public class Oasp4js extends AbstractCommandModule {
     }
   }
 
-  @Command(name = "build", description = "This command will build the oasp4js project.", context = ContextType.PROJECT)
+  @Command(name = "build", description = "This command will build the devon4ng project.", context = ContextType.PROJECT)
   public void build() {
 
     try {
@@ -122,7 +122,7 @@ public class Oasp4js extends AbstractCommandModule {
       }
 
       Process p;
-      if (this.projectInfo.get().getProjecType().equals(ProjectType.OASP4JS)) {
+      if (this.projectInfo.get().getProjecType().equals(ProjectType.DEVON4NG)) {
 
         Process process = null;
 
@@ -149,7 +149,7 @@ public class Oasp4js extends AbstractCommandModule {
 
       } else {
         getOutput()
-            .showError("Seems that you are not in a OASP4JS project. Please verify the devon.json configuration file");
+            .showError("Seems that you are not in a DEVON4NG project. Please verify the devon.json configuration file");
       }
 
     } catch (Exception e) {
@@ -157,7 +157,7 @@ public class Oasp4js extends AbstractCommandModule {
     }
   }
 
-  @Command(name = "run", description = "This command runs a debug build of oasp4js", context = ContextType.PROJECT)
+  @Command(name = "run", description = "This command runs a debug build of devon4ng", context = ContextType.PROJECT)
   public void run() {
 
     try {
@@ -167,7 +167,7 @@ public class Oasp4js extends AbstractCommandModule {
       }
 
       if (this.projectInfo.isPresent()) {
-        if (this.projectInfo.get().getProjecType().equals(ProjectType.OASP4JS)) {
+        if (this.projectInfo.get().getProjecType().equals(ProjectType.DEVON4NG)) {
 
           Process process = null;
 
@@ -195,7 +195,7 @@ public class Oasp4js extends AbstractCommandModule {
 
         } else {
           getOutput().showError(
-              "Seems that you are not in a OASP4JS project. Please verify the devon.json configuration file");
+              "Seems that you are not in a DEVON4NG project. Please verify the devon.json configuration file");
         }
 
       } else {

--- a/src/main/java/com/devonfw/devcon/modules/dist/Dist.java
+++ b/src/main/java/com/devonfw/devcon/modules/dist/Dist.java
@@ -55,20 +55,20 @@ public class Dist extends AbstractCommandModule {
    * @param password the password related to the user with permissions to download the Devon distribution
    * @throws Exception
    */
-  @Command(name = "install", description = "This command downloads the last version of a distribution from Teamforge. You can select between Devonfw distribution (by default) and Oasp-ide distribution.", context = ContextType.NONE)
+  @Command(name = "install", description = "This command downloads the last version of a distribution from Teamforge. You can select between Devonfw distribution (by default) and Devon-ide distribution.", context = ContextType.NONE)
   @Parameters(values = {
   @Parameter(name = "path", description = "a location for the Devon distribution download", optional = true, inputType = @InputType(name = InputTypeNames.PATH)),
-  @Parameter(name = "type", description = "the type of the distribution, the options are: \n 'oaspide' to download OASP IDE\n 'devondist' to download Devon IP IDE", optional = true, inputType = @InputType(name = InputTypeNames.LIST, values = {
-  "devondist"/* ,"oaspide" */ }))/*
-                                  * ,
-                                  *
-                                  * @Parameter(name = "user", description =
-                                  * "a user with permissions to download the Devon distribution"),
-                                  *
-                                  * @Parameter(name = "password", description =
-                                  * "the password related to the user with permissions to download the Devon distribution"
-                                  * , inputType = @InputType(name = InputTypeNames.PASSWORD))
-                                  */ })
+  @Parameter(name = "type", description = "the type of the distribution, the options are: \n 'devonide' to download DEVON IDE\n 'devondist' to download Devon IP IDE", optional = true, inputType = @InputType(name = InputTypeNames.LIST, values = {
+  "devondist"/* ,"devonide" */ }))/*
+                                   * ,
+                                   *
+                                   * @Parameter(name = "user", description =
+                                   * "a user with permissions to download the Devon distribution"),
+                                   *
+                                   * @Parameter(name = "password", description =
+                                   * "the password related to the user with permissions to download the Devon distribution"
+                                   * , inputType = @InputType(name = InputTypeNames.PASSWORD))
+                                   */ })
   public void install(String path, String type/* , String user, String password */) throws Exception {
 
     Optional<String> teamforgeFileId;
@@ -81,7 +81,7 @@ public class Dist extends AbstractCommandModule {
 
     try {
 
-      if (type.toLowerCase().equals(DistConstants.OASP_IDE)) {
+      if (type.toLowerCase().equals(DistConstants.DEVON_IDE)) {
 
       } else if (type.toLowerCase().equals(DistConstants.DEVON_DIST) && SystemUtils.IS_OS_WINDOWS) {
         distType = DistConstants.DIST_TYPE_WINDOWS;

--- a/src/main/java/com/devonfw/devcon/modules/dist/DistConstants.java
+++ b/src/main/java/com/devonfw/devcon/modules/dist/DistConstants.java
@@ -32,14 +32,14 @@ public final class DistConstants {
   public static final String REPOSITORY_URL = "http://de-mucevolve02/files/devonfw/current/";
 
   /**
-   * oasp distribution file id
+   * devon distribution file id
    */
-  public static final String OASP_FILE_ID = "oaspide_file_id";
+  public static final String DEVON_FILE_ID = "devonide_file_id";
 
   /**
    * devon distribution file id
    */
-  public static final String DEVON_FILE_ID = "devondist_file_id";
+  public static final String DEVON_DIST_FILE_ID = "devondist_file_id";
 
   /**
    * devon distribution linux file id
@@ -47,9 +47,9 @@ public final class DistConstants {
   public static final String DEVON_FILE_LINUX_ID = "devondist_file_linux_id";
 
   /**
-   * distribution type for oasp
+   * distribution type for devon
    */
-  public static final String OASP_IDE = DistributionType.OASPIDE.toString().toLowerCase();
+  public static final String DEVON_IDE = DistributionType.DEVONIDE.toString().toLowerCase();
 
   /**
    * distribution type for devon

--- a/src/main/java/com/devonfw/devcon/modules/doc/Doc.java
+++ b/src/main/java/com/devonfw/devcon/modules/doc/Doc.java
@@ -39,7 +39,7 @@ public class Doc extends AbstractCommandModule {
 
   private static final String DEVON_GUIDE = "https://github.com/devonfw/devon/wiki";
 
-  private static final String OASP4J_GUIDE = "https://github.com/oasp/oasp4j/wiki";
+  private static final String OASP4J_GUIDE = "https://github.com/oasp/devon4j/wiki";
 
   private static final String DEVCON_USER_GUIDE = "https://github.com/devonfw/devon/wiki/devcon-user-guide";
 
@@ -79,7 +79,7 @@ public class Doc extends AbstractCommandModule {
   }
 
   @SuppressWarnings("javadoc")
-  @Command(name = "oasp4jguide", description = "Opens the OASP4J Guide")
+  @Command(name = "oasp4jguide", description = "Opens the DEVON4J Guide")
   public void oasp4jguide() {
 
     openUrl(OASP4J_GUIDE);

--- a/src/main/java/com/devonfw/devcon/modules/doc/Doc.java
+++ b/src/main/java/com/devonfw/devcon/modules/doc/Doc.java
@@ -39,7 +39,7 @@ public class Doc extends AbstractCommandModule {
 
   private static final String DEVON_GUIDE = "https://github.com/devonfw/devon/wiki";
 
-  private static final String OASP4J_GUIDE = "https://github.com/oasp/devon4j/wiki";
+  private static final String DEVON4J_GUIDE = "https://github.com/devon/devon4j/wiki";
 
   private static final String DEVCON_USER_GUIDE = "https://github.com/devonfw/devon/wiki/devcon-user-guide";
 
@@ -79,10 +79,10 @@ public class Doc extends AbstractCommandModule {
   }
 
   @SuppressWarnings("javadoc")
-  @Command(name = "oasp4jguide", description = "Opens the DEVON4J Guide")
-  public void oasp4jguide() {
+  @Command(name = "devon4jguide", description = "Opens the DEVON4J Guide")
+  public void devon4jguide() {
 
-    openUrl(OASP4J_GUIDE);
+    openUrl(DEVON4J_GUIDE);
   }
 
   @Command(name = "getstarted", description = "Opens the Devonfw \"Getting Started\" page")

--- a/src/main/java/com/devonfw/devcon/modules/doc/Doc.java
+++ b/src/main/java/com/devonfw/devcon/modules/doc/Doc.java
@@ -39,7 +39,7 @@ public class Doc extends AbstractCommandModule {
 
   private static final String DEVON_GUIDE = "https://github.com/devonfw/devon/wiki";
 
-  private static final String DEVON4J_GUIDE = "https://github.com/devon/devon4j/wiki";
+  private static final String DEVON4J_GUIDE = "https://github.com/devonfw/devon4j/wiki";
 
   private static final String DEVCON_USER_GUIDE = "https://github.com/devonfw/devon/wiki/devcon-user-guide";
 

--- a/src/main/java/com/devonfw/devcon/modules/github/Github.java
+++ b/src/main/java/com/devonfw/devcon/modules/github/Github.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,31 +32,32 @@ import com.devonfw.devcon.common.api.data.InputTypeNames;
 import com.devonfw.devcon.common.impl.AbstractCommandModule;
 
 /**
- * This class contains command to clone oasp4j and devon repositories.
+ * This class contains command to clone devon4j and devon repositories.
  *
  * @author ssarmoka
  */
 @CmdModuleRegistry(name = "github", description = "Module to get Github repositories related to Devonfw.", sort = 4)
 public class Github extends AbstractCommandModule {
 
-  public static final String OASP4J_URL = "https://github.com/oasp/oasp4j.git";
+  public static final String DEVON4J_URL = "https://github.com/oasp/devon4j.git";
 
   public static final String DEVON_URL = "https://github.com/devonfw/devon.git";
 
   public static final String DOT_GIT = ".git";
 
   /**
-   * This command is to clone oasp4j repository.
+   * This command is to clone devon4j repository.
    *
-   * @param path location to download the oasp4j repository.
+   * @param path location to download the devon4j repository.
    * @throws Exception
    */
-  @Command(name = "oasp4j", description = "This command clones oasp4j repository.", context = ContextType.NONE, proxyParams = true)
+  @Command(name = "devon4j", description = "This command clones devon4j repository.", context = ContextType.NONE, proxyParams = true)
   @Parameters(values = {
-  @Parameter(name = "path", description = "a location for the oasp4j download (Current directory if not provided)", optional = true, inputType = @InputType(name = InputTypeNames.PATH)) })
-  public void oasp4j(String path) throws Exception {
+  @Parameter(name = "path", description = "a location for the devon4j download (Current directory if not provided)", optional = true, inputType = @InputType(name = InputTypeNames.PATH)) })
+  public void devon4j(String path) throws Exception {
 
-    path = path.isEmpty() ? this.contextPathInfo.getCurrentWorkingDirectory().toString() + File.separatorChar + "oasp4j"
+    path = path.isEmpty()
+        ? this.contextPathInfo.getCurrentWorkingDirectory().toString() + File.separatorChar + "devon4j"
         : path;
     try {
 
@@ -65,8 +66,8 @@ public class Github extends AbstractCommandModule {
         folder.mkdirs();
       }
 
-      getOutput().showMessage("Cloning from " + OASP4J_URL + " to " + path);
-      Git result = Git.cloneRepository().setURI(OASP4J_URL).setDirectory(folder).call();
+      getOutput().showMessage("Cloning from " + DEVON4J_URL + " to " + path);
+      Git result = Git.cloneRepository().setURI(DEVON4J_URL).setDirectory(folder).call();
       getOutput().showMessage("Stored repository in: " + result.getRepository().getDirectory());
 
     } catch (TransportException te) {
@@ -78,7 +79,7 @@ public class Github extends AbstractCommandModule {
           .showError("Connection error. Please verify your proxy or use the -proxyHost and -proxyPort parameters");
       throw te;
     } catch (Exception e) {
-      getOutput().showError("Getting the OASP4J code from Github: %s", e.getMessage());
+      getOutput().showError("Getting the DEVON4J code from Github: %s", e.getMessage());
       throw e;
     }
 

--- a/src/main/java/com/devonfw/devcon/modules/github/Github.java
+++ b/src/main/java/com/devonfw/devcon/modules/github/Github.java
@@ -39,7 +39,7 @@ import com.devonfw.devcon.common.impl.AbstractCommandModule;
 @CmdModuleRegistry(name = "github", description = "Module to get Github repositories related to Devonfw.", sort = 4)
 public class Github extends AbstractCommandModule {
 
-  public static final String DEVON4J_URL = "https://github.com/oasp/devon4j.git";
+  public static final String DEVON4J_URL = "https://github.com/devonfw/devon4j.git";
 
   public static final String DEVON_URL = "https://github.com/devonfw/devon.git";
 

--- a/src/main/java/com/devonfw/devcon/modules/oasp4j/Oasp4j.java
+++ b/src/main/java/com/devonfw/devcon/modules/oasp4j/Oasp4j.java
@@ -61,7 +61,7 @@ import com.google.common.base.Optional;
  *
  * @author ssarmoka
  */
-@CmdModuleRegistry(name = "oasp4j", description = "Oasp4j(server project) related commands", sort = 3)
+@CmdModuleRegistry(name = "devon4j", description = "Devon4j(server project) related commands", sort = 3)
 public class Oasp4j extends AbstractCommandModule {
 
   /**
@@ -138,14 +138,14 @@ public class Oasp4j extends AbstractCommandModule {
         int result = process.waitFor();
         if (result == 0) {
           getOutput().showMessage("Adding devon.json file...");
-          Utils.addDevonJsonFile(project.toPath(), ProjectType.OASP4J);
+          Utils.addDevonJsonFile(project.toPath(), ProjectType.DEVON4J);
 
           if (Integer.parseInt(oaspTemplateVersion.replaceAll("\\.", "")) <= new Integer("211")) {
             modifyPom(serverpath + File.separator + servername + File.separator + "server" + File.separator + "pom.xml",
                 packagename);
           }
 
-          getOutput().showMessage("Oasp4j project created successfully");
+          getOutput().showMessage("devonp4j project created successfully");
 
         } else {
           throw new Exception("Project creation failed");
@@ -211,7 +211,7 @@ public class Oasp4j extends AbstractCommandModule {
 
     } catch (Exception e) {
 
-      getOutput().showError("An error occured during executing oasp4j Cmd: %s", e.getMessage());
+      getOutput().showError("An error occured during executing devonp4j Cmd: %s", e.getMessage());
     }
   }
 
@@ -245,7 +245,7 @@ public class Oasp4j extends AbstractCommandModule {
       Utils.processOutput(isError, isOutput, this.output);
 
     } catch (Exception e) {
-      getOutput().showError("An error occured during executing oasp4j Cmd" + e.getMessage());
+      getOutput().showError("An error occured during executing devonp4j Cmd" + e.getMessage());
     }
   }
 
@@ -411,7 +411,7 @@ public class Oasp4j extends AbstractCommandModule {
       }
 
     } catch (Exception e) {
-      getOutput().showError("In oasp4j deploy command. " + e.getMessage());
+      getOutput().showError("In devonp4j deploy command. " + e.getMessage());
     }
   }
 
@@ -516,7 +516,7 @@ public class Oasp4j extends AbstractCommandModule {
       }
 
     } catch (Exception e) {
-      getOutput().showError("Error executing oasp4j command " + e.getMessage());
+      getOutput().showError("Error executing devonp4j command " + e.getMessage());
 
     }
 
@@ -571,5 +571,4 @@ public class Oasp4j extends AbstractCommandModule {
     return dependency;
   }
 
- 
 }

--- a/src/main/java/com/devonfw/devcon/modules/project/Project.java
+++ b/src/main/java/com/devonfw/devcon/modules/project/Project.java
@@ -39,7 +39,7 @@ import com.google.common.base.Optional;
 @CmdModuleRegistry(name = "project", description = "Module to automate tasks related to the devon projects (server + client)", visible = true)
 public class Project extends AbstractCommandModule {
 
-  private final String OASP4J = "oasp4j";
+  private final String DEVON4J = "devon4j";
 
   private final String OASP4JS = "oasp4js";
 
@@ -69,8 +69,8 @@ public class Project extends AbstractCommandModule {
         ProjectInfo p = this.projectInfo.get().getSubProjects().get(i);
 
         if (p.getProjecType() == ProjectType.DEVON4J) {
-          Optional<com.devonfw.devcon.common.api.Command> oasp4j = getCommand("devon4j", "build", p);
-          oasp4j.get().exec();
+          Optional<com.devonfw.devcon.common.api.Command> devon4j = getCommand("devon4j", "build", p);
+          devon4j.get().exec();
         }
         if (p.getProjecType() == ProjectType.OASP4JS) {
           Optional<com.devonfw.devcon.common.api.Command> oasp4js_cmd = getCommand("oasp4js", "build", p);
@@ -99,7 +99,7 @@ public class Project extends AbstractCommandModule {
 
     try {
 
-      Optional<com.devonfw.devcon.common.api.Command> createServer = getCommand(this.OASP4J, this.CREATE);
+      Optional<com.devonfw.devcon.common.api.Command> createServer = getCommand(this.DEVON4J, this.CREATE);
 
       combinedprojectpath = combinedprojectpath.isEmpty() ? getContextPathInfo().getCurrentWorkingDirectory().toString()
           : combinedprojectpath;
@@ -108,7 +108,7 @@ public class Project extends AbstractCommandModule {
       if (createServer.isPresent()) {
         createServer.get().exec(combinedprojectpath, servername, packagename, groupid, version, dbtype);
       } else {
-        getOutput().showError("No command create found for oasp4j module.");
+        getOutput().showError("No command create found for devon4j module.");
       }
 
       getOutput().showMessage("Creating client project...");

--- a/src/main/java/com/devonfw/devcon/modules/project/Project.java
+++ b/src/main/java/com/devonfw/devcon/modules/project/Project.java
@@ -41,7 +41,7 @@ public class Project extends AbstractCommandModule {
 
   private final String DEVON4J = "devon4j";
 
-  private final String OASP4JS = "oasp4js";
+  private final String DEVON4NG = "devon4ng";
 
   private final String CREATE = "create";
 
@@ -72,9 +72,9 @@ public class Project extends AbstractCommandModule {
           Optional<com.devonfw.devcon.common.api.Command> devon4j = getCommand("devon4j", "build", p);
           devon4j.get().exec();
         }
-        if (p.getProjecType() == ProjectType.OASP4JS) {
-          Optional<com.devonfw.devcon.common.api.Command> oasp4js_cmd = getCommand("oasp4js", "build", p);
-          oasp4js_cmd.get().exec();
+        if (p.getProjecType() == ProjectType.DEVON4NG) {
+          Optional<com.devonfw.devcon.common.api.Command> devon4ng_cmd = getCommand("devon4ng", "build", p);
+          devon4ng_cmd.get().exec();
         }
       }
 
@@ -92,7 +92,7 @@ public class Project extends AbstractCommandModule {
   @Parameter(name = "groupid", description = "groupid for server project"),
   @Parameter(name = "version", description = "version of server project"),
   @Parameter(name = "dbtype", description = "database type in server project(h2|postgresql|mysql|mariadb|oracle|hana|db2)"),
-  @Parameter(name = "clientname", description = "name for the oasp4js project"),
+  @Parameter(name = "clientname", description = "name for the devon4ng project"),
   @Parameter(name = "clientpath", description = "path where the client project will be created.", optional = true, inputType = @InputType(name = InputTypeNames.PATH)) })
   public void create(String combinedprojectpath, String servername, String packagename, String groupid, String version,
       String dbtype, String clientname, String clientpath) {
@@ -113,15 +113,15 @@ public class Project extends AbstractCommandModule {
 
       getOutput().showMessage("Creating client project...");
 
-      Optional<com.devonfw.devcon.common.api.Command> createOasp4js = getCommand(this.OASP4JS, this.CREATE);
+      Optional<com.devonfw.devcon.common.api.Command> createDevon4ng = getCommand(this.DEVON4NG, this.CREATE);
 
-      if (createOasp4js.isPresent()) {
-        createOasp4js.get().exec(clientname, clientpath);
+      if (createDevon4ng.isPresent()) {
+        createDevon4ng.get().exec(clientname, clientpath);
 
         clientJsonReference = clientpath.isEmpty() ? clientname : clientpath + File.separator + clientname;
 
       } else {
-        getOutput().showError("No command create found for oasp4js module.");
+        getOutput().showError("No command create found for devon4ng module.");
         return;
       }
 
@@ -143,7 +143,7 @@ public class Project extends AbstractCommandModule {
    */
   @Command(name = "run", description = "This command runs the server & client project (unified server and client build) in debug mode. It runs client app and spring boot server seperately.", context = ContextType.COMBINEDPROJECT)
   @Parameters(values = {
-  @Parameter(name = "clientpath", description = "Location of the oasp4js app", optional = true, inputType = @InputType(name = InputTypeNames.PATH)),
+  @Parameter(name = "clientpath", description = "Location of the devon4ng app", optional = true, inputType = @InputType(name = InputTypeNames.PATH)),
   @Parameter(name = "serverport", description = "Port to start server", optional = true),
   @Parameter(name = "serverpath", description = "Path to Server project Workspace (currentDir if not given)", optional = true, inputType = @InputType(name = InputTypeNames.PATH)) })
   public void run(String clientpath, String serverport, String serverpath) {
@@ -164,9 +164,10 @@ public class Project extends AbstractCommandModule {
           Optional<com.devonfw.devcon.common.api.Command> cmd = getCommand(Constants.DEVON4J, Constants.RUN, p);
           cmd.get().exec(serverport);
         } else {
-          String clienttype = Constants.OASP4JS;
-          Optional<com.devonfw.devcon.common.api.Command> oasp4js_cmd = getCommand(Constants.OASP4JS, Constants.RUN, p);
-          oasp4js_cmd.get().exec();
+          String clienttype = Constants.DEVON4NG;
+          Optional<com.devonfw.devcon.common.api.Command> devon4ng_cmd = getCommand(Constants.DEVON4NG, Constants.RUN,
+              p);
+          devon4ng_cmd.get().exec();
         }
       }
 

--- a/src/main/java/com/devonfw/devcon/modules/project/Project.java
+++ b/src/main/java/com/devonfw/devcon/modules/project/Project.java
@@ -68,8 +68,8 @@ public class Project extends AbstractCommandModule {
       for (int i = 0; i < size; i++) {
         ProjectInfo p = this.projectInfo.get().getSubProjects().get(i);
 
-        if (p.getProjecType() == ProjectType.OASP4J) {
-          Optional<com.devonfw.devcon.common.api.Command> oasp4j = getCommand("oasp4j", "build", p);
+        if (p.getProjecType() == ProjectType.DEVON4J) {
+          Optional<com.devonfw.devcon.common.api.Command> oasp4j = getCommand("devon4j", "build", p);
           oasp4j.get().exec();
         }
         if (p.getProjecType() == ProjectType.OASP4JS) {
@@ -160,8 +160,8 @@ public class Project extends AbstractCommandModule {
       for (int i = 0; i < size; i++) {
         ProjectInfo p = this.projectInfo.get().getSubProjects().get(i);
 
-        if (p.getProjecType() == ProjectType.OASP4J) {
-          Optional<com.devonfw.devcon.common.api.Command> cmd = getCommand(Constants.OASP4J, Constants.RUN, p);
+        if (p.getProjecType() == ProjectType.DEVON4J) {
+          Optional<com.devonfw.devcon.common.api.Command> cmd = getCommand(Constants.DEVON4J, Constants.RUN, p);
           cmd.get().exec(serverport);
         } else {
           String clienttype = Constants.OASP4JS;

--- a/src/main/java/com/devonfw/devcon/output/GUIOutput.java
+++ b/src/main/java/com/devonfw/devcon/output/GUIOutput.java
@@ -190,8 +190,8 @@ public class GUIOutput implements Output {
   @Override
   public void showError(String message, String... args) {
 
-    this.consoleOutput.append("\n[ERROR] ");
-    this.consoleOutput.append(String.format(message, args));
+    this.consoleOutput.append("[ERROR] ");
+    this.consoleOutput.append(String.format(message, args)).append("\n");
     this.out_.setText(this.consoleOutput.toString());
   }
 

--- a/src/test/java/com/devonfw/devcon/module/Devon4ngTest.java
+++ b/src/test/java/com/devonfw/devcon/module/Devon4ngTest.java
@@ -65,7 +65,7 @@ public class Devon4ngTest {
     this.commandManager = new CommandManagerImpl(this.registry, this.input, this.output);
     this.inputMgr = new ConsoleInputManager(this.registry, this.input, this.output, this.commandManager);
     this.clientName = "angularProjectTest";
-    this.clientPath = "D:\\devconcreateDevon4ngTestTemp";
+    this.clientPath = "D:\\devconDevon4ngTestTemp";
   }
 
   @Test

--- a/src/test/java/com/devonfw/devcon/module/Devon4ngTest.java
+++ b/src/test/java/com/devonfw/devcon/module/Devon4ngTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,11 +36,11 @@ import com.devonfw.devcon.output.ConsoleOutput;
 import com.devonfw.devcon.output.Output;
 
 /**
- * Tests the Oasp4js module
+ * Tests the Devon4ng module
  *
  * @author pparrado
  */
-public class Oasp4jsTest {
+public class Devon4ngTest {
   ConsoleInputManager inputMgr;
 
   private CommandManager commandManager;
@@ -65,13 +65,13 @@ public class Oasp4jsTest {
     this.commandManager = new CommandManagerImpl(this.registry, this.input, this.output);
     this.inputMgr = new ConsoleInputManager(this.registry, this.input, this.output, this.commandManager);
     this.clientName = "angularProjectTest";
-    this.clientPath = "D:\\devconOasp4jsTestTemp";
+    this.clientPath = "D:\\devconcreateDevon4ngTestTemp";
   }
 
   @Test
   public void create() {
 
-    String[] args = { "oasp4js", "create", "-clientname", this.clientName, "-clientpath", this.clientPath };
+    String[] args = { "devon4ng", "create", "-clientname", this.clientName, "-clientpath", this.clientPath };
 
     assertTrue(this.inputMgr.parse(args));
   }
@@ -81,7 +81,7 @@ public class Oasp4jsTest {
   // @Test
   // public void run() throws IOException, InterruptedException {
   //
-  // String[] args = { "oasp4js", "run", "-clientpath", this.clientPath + File.separator + this.clientName };
+  // String[] args = { "devon4ng", "run", "-clientpath", this.clientPath + File.separator + this.clientName };
   // assertTrue(this.inputMgr.parse(args));
   // }
 

--- a/src/test/java/com/devonfw/devcon/module/DistTest.java
+++ b/src/test/java/com/devonfw/devcon/module/DistTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -64,7 +64,7 @@ public class DistTest {
   public void installFail_WrongUser() {
 
     String[] args = { "-np", "dist", "install", "-path", "C:\\Temp\\myTemp", "-user", "asdf", "-password", "12345",
-    "-type", "oaspide" };
+    "-type", "devonide" };
 
     assertFalse(this.inputMgr.parse(args));
   }

--- a/src/test/java/com/devonfw/devcon/module/FooTest.java
+++ b/src/test/java/com/devonfw/devcon/module/FooTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -175,7 +175,7 @@ public class FooTest {
   public void commandWithOptionalParameter() throws IOException {
 
     Path tmp = FileSystems.getDefault().getPath(System.getProperty("user.dir"));
-    String content = "{\"version\": \"2.0.0\",\n\"type\":\"oasp4j\",\n\"signature\":\"from json\"}";
+    String content = "{\"version\": \"2.0.0\",\n\"type\":\"devon4j\",\n\"signature\":\"from json\"}";
     File tempSettings = tmp.resolve("devon.json").toFile();
     FileUtils.writeStringToFile(tempSettings, content, "UTF-8");
 
@@ -277,7 +277,7 @@ public class FooTest {
     sentence.addParam("second", "Brown");
 
     // Devon project containing missing values
-    String content = "{\"version\": \"2.0.0\",\n\"type\":\"oasp4j\",\n\"first\": \"The\",\n\"fourth\": \"Fox\"\n}";
+    String content = "{\"version\": \"2.0.0\",\n\"type\":\"devon4j\",\n\"first\": \"The\",\n\"fourth\": \"Fox\"\n}";
     File settingsfile = this.testFoo.resolve("devon.json").toFile();
     FileUtils.writeStringToFile(settingsfile, content, "UTF-8");
 

--- a/src/test/java/com/devonfw/devcon/module/ProjectTest.java
+++ b/src/test/java/com/devonfw/devcon/module/ProjectTest.java
@@ -116,9 +116,9 @@ public class ProjectTest {
   @Test
   public void createServerWithAngular() {
 
-    this.clientName = "oasp4jsTest";
+    this.clientName = "Devon4ngTest";
     this.clientPath = this.serverPath;
-    String clientType = "oasp4js";
+    String clientType = "Devon4ng";
     this.dbtype = "h2";
 
     String[] args = { "project", "create", "-servername", this.serverName, "-combinedprojectpath", this.serverPath,

--- a/src/test/java/com/devonfw/devcon/module/UtilsTest.java
+++ b/src/test/java/com/devonfw/devcon/module/UtilsTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2015-2018 Capgemini SE.
- * 
+ *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,40 +26,37 @@ import org.junit.Test;
 import com.devonfw.devcon.common.utils.Constants;
 import com.devonfw.devcon.common.utils.Utils;
 
-
 /**
  * Tests the Utils module
  *
  * @author dsanchez
  */
 public class UtilsTest {
-	
-  	
+
   @SuppressWarnings("javadoc")
   @Before
   public void setup() {
 
-  
   }
 
   @Test
   public void testGetTemplateVersion() throws URISyntaxException {
 
-  	String configPath = this.getClass().getResource("").getPath().replace("com/devonfw/devcon/module/", "") + Constants.VERSION_PARAMS_FILE_FULL_PATH;	  
-  	String templateVersion = Utils.getTemplateVersion(configPath);
-    assertTrue(templateVersion.equals("2.6.0"));
+    String configPath = this.getClass().getResource("").getPath().replace("com/devonfw/devcon/module/", "")
+        + Constants.VERSION_PARAMS_FILE_FULL_PATH;
+    String templateVersion = Utils.getTemplateVersion(configPath);
+    assertTrue(templateVersion.equals("3.0.0"));
   }
-  
+
   @Test
   public void testRemoveEndingDot() throws URISyntaxException {
 
-  	String path = this.getClass().getResource("").getPath() + ".";  	
-  	path = Utils.removeEndingDot(path);  	
+    String path = this.getClass().getResource("").getPath() + ".";
+    path = Utils.removeEndingDot(path);
     assertTrue(path.equals(this.getClass().getResource("").getPath()));
-    path = Utils.removeEndingDot(path);    
+    path = Utils.removeEndingDot(path);
     assertTrue(path.equals(this.getClass().getResource("").getPath()));
   }
-
 
   @After
   public void end() {

--- a/src/test/resources/conf/version.json
+++ b/src/test/resources/conf/version.json
@@ -3,8 +3,8 @@
   "url":"http://devonfw.github.io/download/devcon/devcon.jar",
   "devondist_file_id": "frs65334",
   "devondist_file_linux_id": "frs65335",
-  "oaspide_file_id": "frs54315",
-  "oasp4js_ang1_id": "frs51721",
-  "oasp4js_ang2_id": "frs51961",
-  "oasp_template_version": "3.0.0"
+  "devonide_file_id": "frs54315",
+  "devon4ng_ang1_id": "frs51721",
+  "devon4ng_ang2_id": "frs51961",
+  "devon_template_version": "3.0.0"
 }

--- a/src/test/resources/conf/version.json
+++ b/src/test/resources/conf/version.json
@@ -6,5 +6,5 @@
   "oaspide_file_id": "frs54315",
   "oasp4js_ang1_id": "frs51721",
   "oasp4js_ang2_id": "frs51961",
-  "oasp_template_version": "2.6.0"
+  "oasp_template_version": "3.0.0"
 }

--- a/terms-of-use.txt
+++ b/terms-of-use.txt
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 # //
 #-------------------------------------------------------------------------------
-We provide the computer program of devonfw and DEVON (the Open Application Standard Platform), (hereinafter "Software") free of charge to download. 
+We provide the computer program of devonfw and OASP (the Open Application Standard Platform), (hereinafter "Software") free of charge to download. 
 Regarding this software the license terms of the Apache License 2.0 apply. The user shall be responsible to provide the required system environment 
 for using the software. In accordance with the license terms of the Apache License 2.0, the user is entitled to use the Software in own / other
  projects (also commercial projects), provided that the copyright notice will be taken.
@@ -11,5 +11,5 @@ The open-source components of third parties are not from us and must be licensed
 The rights to use will be granted directly by the respective right owner to the extent of each relevant open source license terms. 
 The user himself can download the desired third party component from the servers of the respective provider and install them in his own environment.
 
-For a full list of the open-source components of third-parties  and applicable license terms, see: https://devon.github.io/TermsOfUse
+For a full list of the open-source components of third-parties  and applicable license terms, see: https://oasp.github.io/TermsOfUse
 

--- a/terms-of-use.txt
+++ b/terms-of-use.txt
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------
 # //
 #-------------------------------------------------------------------------------
-We provide the computer program of devonfw and OASP (the Open Application Standard Platform), (hereinafter "Software") free of charge to download. 
+We provide the computer program of devonfw and DEVON (the Open Application Standard Platform), (hereinafter "Software") free of charge to download. 
 Regarding this software the license terms of the Apache License 2.0 apply. The user shall be responsible to provide the required system environment 
 for using the software. In accordance with the license terms of the Apache License 2.0, the user is entitled to use the Software in own / other
  projects (also commercial projects), provided that the copyright notice will be taken.
@@ -11,5 +11,5 @@ The open-source components of third parties are not from us and must be licensed
 The rights to use will be granted directly by the respective right owner to the extent of each relevant open source license terms. 
 The user himself can download the desired third party component from the servers of the respective provider and install them in his own environment.
 
-For a full list of the open-source components of third-parties  and applicable license terms, see: https://oasp.github.io/TermsOfUse
+For a full list of the open-source components of third-parties  and applicable license terms, see: https://devon.github.io/TermsOfUse
 


### PR DESCRIPTION
Further improvements for #135 
Still a newly migrated app will most probably end up with errors like:
```
There is no PasswordEncoder mapped for the id "null"
```
Unfortunately spring-boot cares too less for backward compatibility. I covered all package refactorings, etc. but to fix this last aspect, I would to deep-dive into the code details. This would require to find the proper sub-class of `WebSecurityConfigurerAdapter` that is responsible for the security config and insert the password encoder there into the code. I really dislike the way spring-boot removed defaults and left the users alone with the problem.
However, the only chance I see here is that we write a proper migration guide documentation for such manual steps and output the URL to this guide in devcon as we would need AI to automate such code migration feature.